### PR TITLE
fix(mcp): tolerate LLM-generated tool arguments (#24)

### DIFF
--- a/scripts/issue24-dod-suite.mjs
+++ b/scripts/issue24-dod-suite.mjs
@@ -88,7 +88,20 @@ const CASES = [
 	{ cls: 'CTRL', name: 'notes Mark 9:1 (single-digit)', tool: 'fetch_translation_notes', args: { reference: 'Mark 9:1', language: 'en' }, kind: 'data', minItems: 1 },
 	{ cls: 'CTRL', name: 'scripture John 3:16', tool: 'fetch_scripture', args: { reference: 'John 3:16', language: 'en' }, kind: 'ok', expectText: 'John' },
 	{ cls: 'CTRL', name: 'word path=bible/kt/love (canonical path)', tool: 'fetch_translation_word', args: { path: 'bible/kt/love', language: 'en' }, kind: 'ok', expectText: 'love' },
-	{ cls: 'CTRL', name: 'academy path=translate/figs-metaphor', tool: 'fetch_translation_academy', args: { path: 'translate/figs-metaphor', language: 'en' }, kind: 'ok', expectText: 'etaphor' }
+	{ cls: 'CTRL', name: 'academy path=translate/figs-metaphor', tool: 'fetch_translation_academy', args: { path: 'translate/figs-metaphor', language: 'en' }, kind: 'ok', expectText: 'etaphor' },
+
+	// ── REAL prod failures: exact (tool, args) from 7-day prod log (issue #24) ──
+	// NL prompt text is not logged (redacted); these are the verbatim args the
+	// model emitted. #6 (scripture, language:"en-US") is a separate language-
+	// variant issue, out of scope — tracked separately, not included here.
+	{ cls: 'PROD', name: '#1 notes {reference:"MAR 10:25"}', tool: 'fetch_translation_notes', args: { reference: 'MAR 10:25' }, kind: 'data', minItems: 1 },
+	{ cls: 'PROD', name: '#2 word {word:"new creation"}', tool: 'fetch_translation_word', args: { word: 'new creation' }, kind: 'resolves' },
+	{ cls: 'PROD', name: '#3 word {term:"lovingkindness"}', tool: 'fetch_translation_word', args: { term: 'lovingkindness' }, kind: 'resolves' },
+	{ cls: 'PROD', name: '#4 word {name:"god",language:"en",format:"md"}', tool: 'fetch_translation_word', args: { name: 'god', language: 'en', format: 'md' }, kind: 'ok', expectText: 'god' },
+	{ cls: 'PROD', name: '#5 notes {includeIntro,reference:"Genesis 1:1-3",format:json}', tool: 'fetch_translation_notes', args: { includeIntro: true, reference: 'Genesis 1:1-3', format: 'json' }, kind: 'resolves' },
+	{ cls: 'PROD', name: '#7 notes {includeIntro,reference:"GEN 1:1-3",format:json}', tool: 'fetch_translation_notes', args: { includeIntro: true, reference: 'GEN 1:1-3', format: 'json' }, kind: 'resolves' },
+	{ cls: 'PROD', name: '#8 notes {reference:"EZK 36:25-27"} (parse fixed; verse no-data)', tool: 'fetch_translation_notes', args: { reference: 'EZK 36:25-27' }, kind: 'resolves' },
+	{ cls: 'PROD', name: '#9 notes {reference:"Ruth 3:9",language:"pt"}', tool: 'fetch_translation_notes', args: { reference: 'Ruth 3:9', language: 'pt' }, kind: 'resolves' }
 ];
 
 async function callTool(tool, args) {

--- a/scripts/issue24-dod-suite.mjs
+++ b/scripts/issue24-dod-suite.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * Issue #24 — Definition-of-Done repro suite.
+ *
+ * Enumerates every distinct failing-input pattern from the production logs
+ * (Classes A, B, C, D, E/F, H) plus a set of previously-working "control"
+ * inputs that must NOT regress. Runs each as a real JSON-RPC `tools/call`
+ * against a target `/api/mcp` and reports pass/fail.
+ *
+ * Usage:
+ *   node scripts/issue24-dod-suite.mjs <base-url>
+ *   node scripts/issue24-dod-suite.mjs https://tc-helps.mcp.servant.bible
+ *   node scripts/issue24-dod-suite.mjs http://localhost:8788
+ *
+ * A case "passes" when its expectation holds:
+ *   - kind:"ok"   → call returns a result (no JSON-RPC error) AND, if `expectText`
+ *                   is given, the result text contains it.
+ *   - kind:"data" → call returns a result whose text parses to non-empty data
+ *                   (>= `minItems` items where applicable).
+ *   - kind:"error"→ call returns a JSON-RPC error (used only for control/negative).
+ *
+ * Exit code 0 only if every case passes.
+ */
+
+const base = (process.argv[2] || 'https://tc-helps.mcp.servant.bible').replace(/\/+$/, '');
+const endpoint = `${base}/api/mcp`;
+
+/**
+ * @typedef {Object} Case
+ * @property {string} cls   Failure class (A/B/C/D/E/F/H/CTRL)
+ * @property {string} name  Human label
+ * @property {string} tool  MCP tool name
+ * @property {any}    args  Raw arguments object (sent verbatim)
+ * @property {'ok'|'data'|'error'} kind
+ * @property {string=} expectText  substring expected in result text (kind ok)
+ * @property {number=} minItems    minimum array length (kind data)
+ */
+
+/** @type {Case[]} */
+const CASES = [
+	// ── Class A: multi-digit chapter (the item-1 server bug) ─────────────
+	{ cls: 'A', name: 'notes Mark 10:25 (multi-digit)', tool: 'fetch_translation_notes', args: { reference: 'Mark 10:25', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'notes Matthew 13:55 (multi-digit)', tool: 'fetch_translation_notes', args: { reference: 'Matthew 13:55', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'notes Genesis 50:1 (multi-digit)', tool: 'fetch_translation_notes', args: { reference: 'Genesis 50:1', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'questions Mark 10:25 (multi-digit)', tool: 'fetch_translation_questions', args: { reference: 'Mark 10:25', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'notes Mark 10 (whole multi-digit chapter)', tool: 'fetch_translation_notes', args: { reference: 'Mark 10', language: 'en' }, kind: 'data', minItems: 1 },
+
+	// ── Class A: invalid / spaceless USFM codes ──────────────────────────
+	{ cls: 'A', name: 'notes MAR 10:25 (invalid code MAR→MRK)', tool: 'fetch_translation_notes', args: { reference: 'MAR 10:25', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'notes 2KI 12:8 (spaceless numbered code)', tool: 'fetch_translation_notes', args: { reference: '2KI 12:8', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'notes 2KGS 12:8 (invalid code 2KGS→2KI)', tool: 'fetch_translation_notes', args: { reference: '2KGS 12:8', language: 'en' }, kind: 'data', minItems: 1 },
+
+	// ── Class B: missing path; word/term synonyms ────────────────────────
+	{ cls: 'B', name: 'word term=love (alias term→path)', tool: 'fetch_translation_word', args: { term: 'love', language: 'en' }, kind: 'ok', expectText: 'love' },
+	{ cls: 'B', name: 'word word=grace (alias word→path)', tool: 'fetch_translation_word', args: { word: 'grace', language: 'en' }, kind: 'ok', expectText: 'grace' },
+	{ cls: 'B', name: 'word term=abraham (names category)', tool: 'fetch_translation_word', args: { term: 'abraham', language: 'en' }, kind: 'ok', expectText: 'Abraham' },
+	{ cls: 'B', name: 'academy term=figs-metaphor (alias term→path)', tool: 'fetch_translation_academy', args: { term: 'figs-metaphor', language: 'en' }, kind: 'ok', expectText: 'etaphor' },
+
+	// ── Class C: decomposed book+chapter+verse → reference ────────────────
+	{ cls: 'C', name: 'notes decomposed 1CO 15:58', tool: 'fetch_translation_notes', args: { book: '1CO', chapter: 15, verse: 58, language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'C', name: 'word_links decomposed John 3:16', tool: 'fetch_translation_word_links', args: { book: 'John', chapter: 3, verse: 16, language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'C', name: 'questions decomposed Mark 10:25', tool: 'fetch_translation_questions', args: { book: 'Mark', chapter: 10, verse: 25, language: 'en' }, kind: 'data', minItems: 1 },
+
+	// ── Class D: language_code alias → language ──────────────────────────
+	{ cls: 'D', name: 'list_resources language_code=en', tool: 'list_resources_for_language', args: { language_code: 'en' }, kind: 'ok', expectText: 'en' },
+
+	// ── Class E/F: scripture long / numbered names ───────────────────────
+	{ cls: 'E/F', name: 'scripture James 1:13-15 (long name)', tool: 'fetch_scripture', args: { reference: 'James 1:13-15', language: 'en' }, kind: 'ok', expectText: 'James' },
+	{ cls: 'E/F', name: 'scripture 1 Corinthians 13:4-7 (numbered name)', tool: 'fetch_scripture', args: { reference: '1 Corinthians 13:4-7', language: 'en' }, kind: 'ok' },
+
+	// ── Class H: null / array args ───────────────────────────────────────
+	{ cls: 'H', name: 'list_languages args=[] (array)', tool: 'list_languages', args: [], kind: 'ok' },
+	{ cls: 'H', name: 'list_languages args=null (null)', tool: 'list_languages', args: null, kind: 'ok' },
+
+	// ── Controls: must keep working (no regressions) ─────────────────────
+	{ cls: 'CTRL', name: 'notes John 3:16 (single-digit)', tool: 'fetch_translation_notes', args: { reference: 'John 3:16', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'CTRL', name: 'notes Mark 9:1 (single-digit)', tool: 'fetch_translation_notes', args: { reference: 'Mark 9:1', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'CTRL', name: 'scripture John 3:16', tool: 'fetch_scripture', args: { reference: 'John 3:16', language: 'en' }, kind: 'ok', expectText: 'John' },
+	{ cls: 'CTRL', name: 'word path=bible/kt/love (canonical path)', tool: 'fetch_translation_word', args: { path: 'bible/kt/love', language: 'en' }, kind: 'ok', expectText: 'love' },
+	{ cls: 'CTRL', name: 'academy path=translate/figs-metaphor', tool: 'fetch_translation_academy', args: { path: 'translate/figs-metaphor', language: 'en' }, kind: 'ok', expectText: 'etaphor' }
+];
+
+async function callTool(tool, args) {
+	const res = await fetch(endpoint, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+		body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: tool, arguments: args } })
+	});
+	const text = await res.text();
+	let parsed;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		// Maybe SSE framing: pull the data: line
+		const m = text.match(/data:\s*(\{.*\})/s);
+		parsed = m ? JSON.parse(m[1]) : { raw: text };
+	}
+	return { status: res.status, parsed };
+}
+
+/** Extract the result text payload and any decoded JSON-of-text. */
+function resultText(parsed) {
+	const content = parsed?.result?.content;
+	if (Array.isArray(content)) {
+		return content.map((c) => c?.text ?? '').join('\n');
+	}
+	return '';
+}
+
+function countItems(text) {
+	try {
+		const obj = JSON.parse(text);
+		for (const f of ['items', 'verseNotes', 'notes', 'questions', 'translationQuestions', 'scripture', 'scriptures']) {
+			if (Array.isArray(obj?.[f])) return obj[f].length;
+		}
+		// single-article shapes
+		if (obj?.content || obj?.text || obj?.definition) return 1;
+		return 0;
+	} catch {
+		return text.trim() ? 1 : 0;
+	}
+}
+
+function evaluate(c, status, parsed) {
+	const err = parsed?.error;
+	const text = resultText(parsed);
+	if (c.kind === 'error') {
+		return { pass: Boolean(err), detail: err ? `error: ${err.message?.slice(0, 80)}` : 'expected error, got result' };
+	}
+	if (err) {
+		return { pass: false, detail: `JSON-RPC error: ${String(err.message).slice(0, 120)}` };
+	}
+	if (c.kind === 'ok') {
+		if (c.expectText && !text.toLowerCase().includes(c.expectText.toLowerCase())) {
+			return { pass: false, detail: `result missing "${c.expectText}" (got ${text.slice(0, 80)}…)` };
+		}
+		return { pass: text.trim().length > 0, detail: text.trim() ? 'ok' : 'empty result' };
+	}
+	if (c.kind === 'data') {
+		const n = countItems(text);
+		return { pass: n >= (c.minItems ?? 1), detail: `${n} item(s)` };
+	}
+	return { pass: false, detail: 'unknown kind' };
+}
+
+async function main() {
+	console.log(`\nIssue #24 DoD suite → ${endpoint}\n${'─'.repeat(64)}`);
+	const results = [];
+	for (const c of CASES) {
+		let line;
+		try {
+			const { status, parsed } = await callTool(c.tool, c.args);
+			const { pass, detail } = evaluate(c, status, parsed);
+			results.push({ c, pass });
+			line = `${pass ? 'PASS' : 'FAIL'}  [${c.cls.padEnd(4)}] ${c.name}  — ${detail}`;
+		} catch (e) {
+			results.push({ c, pass: false });
+			line = `FAIL  [${c.cls.padEnd(4)}] ${c.name}  — threw: ${e.message}`;
+		}
+		console.log(line);
+	}
+	const passed = results.filter((r) => r.pass).length;
+	console.log('─'.repeat(64));
+	console.log(`${passed}/${results.length} passed`);
+	const failed = results.filter((r) => !r.pass);
+	if (failed.length) {
+		console.log('\nFailing:');
+		for (const r of failed) console.log(`  - [${r.c.cls}] ${r.c.name}`);
+	}
+	process.exit(failed.length ? 1 : 0);
+}
+
+main();

--- a/scripts/issue24-dod-suite.mjs
+++ b/scripts/issue24-dod-suite.mjs
@@ -13,14 +13,23 @@
  *   node scripts/issue24-dod-suite.mjs http://localhost:8788
  *
  * A case "passes" when its expectation holds:
- *   - kind:"ok"   → call returns a result (no JSON-RPC error) AND, if `expectText`
- *                   is given, the result text contains it.
- *   - kind:"data" → call returns a result whose text parses to non-empty data
- *                   (>= `minItems` items where applicable).
- *   - kind:"error"→ call returns a JSON-RPC error (used only for control/negative).
+ *   - kind:"ok"      → result returned (no JSON-RPC error) AND, if `expectText`
+ *                      given, the result text contains it.
+ *   - kind:"data"    → result text parses to >= `minItems` items.
+ *   - kind:"resolves"→ the input is no longer *parse-rejected*: either a result
+ *                      is returned, or the only error is a downstream "no data
+ *                      for this verse" 404. A genuine parse/validation rejection
+ *                      (Invalid reference / Missing parameter) still fails. This
+ *                      is the correct bar for the parser fix: resolving "2KI 12:8"
+ *                      to a real book that simply has no verse note is success.
+ *   - kind:"error"   → expects a JSON-RPC error (control/negative).
  *
  * Exit code 0 only if every case passes.
  */
+
+/** Error messages that mean the input was REJECTED before reaching real data. */
+const PARSE_REJECTION =
+	/invalid bible reference|invalid book reference|invalid reference format|missing required parameter|could not (parse|determine)|expected record/i;
 
 const base = (process.argv[2] || 'https://tc-helps.mcp.servant.bible').replace(/\/+$/, '');
 const endpoint = `${base}/api/mcp`;
@@ -42,13 +51,15 @@ const CASES = [
 	{ cls: 'A', name: 'notes Mark 10:25 (multi-digit)', tool: 'fetch_translation_notes', args: { reference: 'Mark 10:25', language: 'en' }, kind: 'data', minItems: 1 },
 	{ cls: 'A', name: 'notes Matthew 13:55 (multi-digit)', tool: 'fetch_translation_notes', args: { reference: 'Matthew 13:55', language: 'en' }, kind: 'data', minItems: 1 },
 	{ cls: 'A', name: 'notes Genesis 50:1 (multi-digit)', tool: 'fetch_translation_notes', args: { reference: 'Genesis 50:1', language: 'en' }, kind: 'data', minItems: 1 },
-	{ cls: 'A', name: 'questions Mark 10:25 (multi-digit)', tool: 'fetch_translation_questions', args: { reference: 'Mark 10:25', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'questions Mark 10:23 (multi-digit, has data)', tool: 'fetch_translation_questions', args: { reference: 'Mark 10:23', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'questions Mark 10:25 (multi-digit, resolves)', tool: 'fetch_translation_questions', args: { reference: 'Mark 10:25', language: 'en' }, kind: 'resolves' },
 	{ cls: 'A', name: 'notes Mark 10 (whole multi-digit chapter)', tool: 'fetch_translation_notes', args: { reference: 'Mark 10', language: 'en' }, kind: 'data', minItems: 1 },
 
 	// ── Class A: invalid / spaceless USFM codes ──────────────────────────
 	{ cls: 'A', name: 'notes MAR 10:25 (invalid code MAR→MRK)', tool: 'fetch_translation_notes', args: { reference: 'MAR 10:25', language: 'en' }, kind: 'data', minItems: 1 },
-	{ cls: 'A', name: 'notes 2KI 12:8 (spaceless numbered code)', tool: 'fetch_translation_notes', args: { reference: '2KI 12:8', language: 'en' }, kind: 'data', minItems: 1 },
-	{ cls: 'A', name: 'notes 2KGS 12:8 (invalid code 2KGS→2KI)', tool: 'fetch_translation_notes', args: { reference: '2KGS 12:8', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'notes 2KI 5:1 (spaceless code, has data)', tool: 'fetch_translation_notes', args: { reference: '2KI 5:1', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'notes 2KGS 5:1 (invalid code 2KGS→2KI, has data)', tool: 'fetch_translation_notes', args: { reference: '2KGS 5:1', language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'A', name: 'notes 2KI 12:8 (issue example, resolves)', tool: 'fetch_translation_notes', args: { reference: '2KI 12:8', language: 'en' }, kind: 'resolves' },
 
 	// ── Class B: missing path; word/term synonyms ────────────────────────
 	{ cls: 'B', name: 'word term=love (alias term→path)', tool: 'fetch_translation_word', args: { term: 'love', language: 'en' }, kind: 'ok', expectText: 'love' },
@@ -59,7 +70,7 @@ const CASES = [
 	// ── Class C: decomposed book+chapter+verse → reference ────────────────
 	{ cls: 'C', name: 'notes decomposed 1CO 15:58', tool: 'fetch_translation_notes', args: { book: '1CO', chapter: 15, verse: 58, language: 'en' }, kind: 'data', minItems: 1 },
 	{ cls: 'C', name: 'word_links decomposed John 3:16', tool: 'fetch_translation_word_links', args: { book: 'John', chapter: 3, verse: 16, language: 'en' }, kind: 'data', minItems: 1 },
-	{ cls: 'C', name: 'questions decomposed Mark 10:25', tool: 'fetch_translation_questions', args: { book: 'Mark', chapter: 10, verse: 25, language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'C', name: 'questions decomposed Mark 10:23', tool: 'fetch_translation_questions', args: { book: 'Mark', chapter: 10, verse: 23, language: 'en' }, kind: 'data', minItems: 1 },
 
 	// ── Class D: language_code alias → language ──────────────────────────
 	{ cls: 'D', name: 'list_resources language_code=en', tool: 'list_resources_for_language', args: { language_code: 'en' }, kind: 'ok', expectText: 'en' },
@@ -126,6 +137,12 @@ function evaluate(c, status, parsed) {
 	const text = resultText(parsed);
 	if (c.kind === 'error') {
 		return { pass: Boolean(err), detail: err ? `error: ${err.message?.slice(0, 80)}` : 'expected error, got result' };
+	}
+	if (c.kind === 'resolves') {
+		if (!err) return { pass: true, detail: 'resolved (returned data)' };
+		const msg = String(err.message || '');
+		if (PARSE_REJECTION.test(msg)) return { pass: false, detail: `parse-rejected: ${msg.slice(0, 90)}` };
+		return { pass: true, detail: `resolved (no-data: ${msg.slice(0, 70)})` };
 	}
 	if (err) {
 		return { pass: false, detail: `JSON-RPC error: ${String(err.message).slice(0, 120)}` };

--- a/scripts/issue24-dod-suite.mjs
+++ b/scripts/issue24-dod-suite.mjs
@@ -101,7 +101,9 @@ const CASES = [
 	{ cls: 'PROD', name: '#5 notes {includeIntro,reference:"Genesis 1:1-3",format:json}', tool: 'fetch_translation_notes', args: { includeIntro: true, reference: 'Genesis 1:1-3', format: 'json' }, kind: 'resolves' },
 	{ cls: 'PROD', name: '#7 notes {includeIntro,reference:"GEN 1:1-3",format:json}', tool: 'fetch_translation_notes', args: { includeIntro: true, reference: 'GEN 1:1-3', format: 'json' }, kind: 'resolves' },
 	{ cls: 'PROD', name: '#8 notes {reference:"EZK 36:25-27"} (parse fixed; verse no-data)', tool: 'fetch_translation_notes', args: { reference: 'EZK 36:25-27' }, kind: 'resolves' },
-	{ cls: 'PROD', name: '#9 notes {reference:"Ruth 3:9",language:"pt"}', tool: 'fetch_translation_notes', args: { reference: 'Ruth 3:9', language: 'pt' }, kind: 'resolves' }
+	{ cls: 'PROD', name: '#9 notes {reference:"Ruth 3:9",language:"pt"}', tool: 'fetch_translation_notes', args: { reference: 'Ruth 3:9', language: 'pt' }, kind: 'resolves' },
+	// Straggler found in staging A/B logs: model used `article` as the path synonym.
+	{ cls: 'PROD', name: 'academy {article:"translate-names"} (alias article→path)', tool: 'fetch_translation_academy', args: { article: 'translate-names' }, kind: 'ok', expectText: 'name' }
 ];
 
 async function callTool(tool, args) {

--- a/scripts/issue24-heavy-smoke.mjs
+++ b/scripts/issue24-heavy-smoke.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/**
+ * Issue #24 — HEAVY smoke suite (breadth beyond the DoD gate).
+ *
+ * Generates a wide matrix of tool calls covering every failure class with many
+ * books / chapters / aliases, plus regression controls, and runs them against a
+ * target /api/mcp with a small concurrency pool. Reports a per-class summary.
+ *
+ * Assertion semantics:
+ *   - 'ok'      : JSON-RPC result returned, non-empty text.
+ *   - 'resolves': input no longer parse-rejected — a result, or a downstream
+ *                 "no data for this verse" 404 (a parsed ref with no verse note
+ *                 is a PASS; only Invalid-reference / Missing-param fails). This
+ *                 is the right bar for the parser/alias fix across many books.
+ *   - 'data' : result text parses to >= minItems items (curated cases known to
+ *              have data).
+ *   - 'has'  : result text contains a substring (case-insensitive).
+ *   - 'error': expects a JSON-RPC error (negative controls).
+ *
+ * Usage: node scripts/issue24-heavy-smoke.mjs <base-url> [concurrency]
+ */
+
+const base = (process.argv[2] || 'https://tc-helps.mcp.servant.bible').replace(/\/+$/, '');
+const CONC = Number(process.argv[3] || 6);
+const endpoint = `${base}/api/mcp`;
+
+const cases = [];
+const add = (cls, name, tool, args, kind, extra = {}) =>
+	cases.push({ cls, name, tool, args, kind, ...extra });
+
+// ── Class A: multi-digit chapters across OT + NT, notes AND questions ──────
+const MULTIDIGIT = [
+	'Genesis 50:20', 'Exodus 20:3', 'Leviticus 19:18', 'Numbers 22:28', 'Deuteronomy 28:1',
+	'Joshua 24:15', 'Judges 16:17', '1 Samuel 17:45', '2 Kings 12:8', '2 Chronicles 20:15',
+	'Nehemiah 13:1', 'Job 38:4', 'Isaiah 53:5', 'Jeremiah 29:11', 'Ezekiel 37:4',
+	'Daniel 12:2', 'Matthew 13:55', 'Matthew 27:46', 'Mark 10:25', 'Mark 14:36',
+	'Luke 15:11', 'Luke 24:27', 'John 11:35', 'John 21:15', 'Acts 17:11',
+	'Romans 12:1', '1 Corinthians 13:4', '1 Corinthians 15:58', '2 Corinthians 12:9',
+	'Galatians 11:1' /* invalid chapter — negative-ish, see below */, 'Hebrews 11:1',
+	'Revelation 21:4', 'Revelation 22:13'
+];
+for (const r of MULTIDIGIT) {
+	// Galatians has no chapter 11 — expect a clean response, not a parse 400.
+	add('A', `notes ${r}`, 'fetch_translation_notes', { reference: r, language: 'en' }, 'resolves');
+}
+for (const r of ['Mark 10:25', 'Matthew 13:55', 'John 11:35', 'Romans 12:1', 'Revelation 21:4', 'Genesis 50:20']) {
+	add('A', `questions ${r}`, 'fetch_translation_questions', { reference: r, language: 'en' }, 'resolves');
+	add('A', `word_links ${r}`, 'fetch_translation_word_links', { reference: r, language: 'en' }, 'resolves');
+}
+// whole multi-digit chapters
+for (const r of ['Mark 10', 'Matthew 13', 'Psalms 119', 'Genesis 50', 'Acts 17']) {
+	add('A', `notes whole-ch ${r}`, 'fetch_translation_notes', { reference: r, language: 'en' }, 'resolves');
+}
+
+// ── Class A: invalid / spaceless / odd codes ──────────────────────────────
+const ODD_CODES = [
+	'MAR 10:25', 'MAR 1:1', '2KI 12:8', '2KGS 12:8', '1KGS 8:1', '2KI 2:11',
+	'1Co 13:4', '1CO 15:58', '2Co 12:9', '1Jn 4:8', '3Jn 1:4', '1Th 4:16',
+	'2Ti 3:16', 'Php 4:13', 'Jas 1:5', 'Rev 21:4'
+];
+for (const r of ODD_CODES) {
+	add('A', `notes code ${r}`, 'fetch_translation_notes', { reference: r, language: 'en' }, 'resolves');
+}
+
+// ── Class B: term/word/path aliases for words; term/moduleId for academy ──
+const WORDS = ['love', 'grace', 'faith', 'covenant', 'abraham', 'moses', 'jerusalem', 'sabbath', 'shepherd'];
+for (const w of WORDS) {
+	add('B', `word term=${w}`, 'fetch_translation_word', { term: w, language: 'en' }, 'has', { needle: w });
+}
+add('B', 'word word=grace', 'fetch_translation_word', { word: 'grace', language: 'en' }, 'has', { needle: 'grace' });
+add('B', 'word path=love (bare)', 'fetch_translation_word', { path: 'love', language: 'en' }, 'has', { needle: 'love' });
+add('B', 'word topic-as-name=faith', 'fetch_translation_word', { topic: 'faith', language: 'en' }, 'has', { needle: 'faith' });
+const MODULES = ['figs-metaphor', 'figs-simile', 'figs-activepassive', 'translate-names', 'figs-hyperbole'];
+for (const m of MODULES) {
+	add('B', `academy term=${m}`, 'fetch_translation_academy', { term: m, language: 'en' }, 'resolves');
+	add('B', `academy moduleId=${m}`, 'fetch_translation_academy', { moduleId: m, language: 'en' }, 'resolves');
+}
+
+// ── Class C: decomposed book+chapter+verse across all ref tools ───────────
+const DECOMP = [
+	{ tool: 'fetch_translation_notes', book: '1CO', chapter: 15, verse: 58 },
+	{ tool: 'fetch_translation_notes', book: 'Mark', chapter: 10, verse: 25 },
+	{ tool: 'fetch_translation_questions', book: 'Mark', chapter: 10, verse: 25 },
+	{ tool: 'fetch_translation_questions', book: 'John', chapter: 3, verse: 16 },
+	{ tool: 'fetch_translation_word_links', book: 'John', chapter: 3, verse: 16 },
+	{ tool: 'fetch_translation_word_links', book: 'Romans', chapter: 12, verse: 1 },
+	{ tool: 'fetch_scripture', book: 'John', chapter: 3, verse: 16 },
+	{ tool: 'fetch_scripture', book: 'Matthew', chapter: 13, verse: 55 }
+];
+for (const d of DECOMP) {
+	add('C', `${d.tool} {${d.book} ${d.chapter}:${d.verse}}`, d.tool, { book: d.book, chapter: d.chapter, verse: d.verse, language: 'en' }, 'resolves');
+}
+// decomposed with endVerse / chapter range
+add('C', 'notes decomposed range 1CO 13:4-7', 'fetch_translation_notes', { book: '1CO', chapter: 13, verse: 4, endVerse: 7, language: 'en' }, 'resolves');
+
+// ── Class D: language synonyms ───────────────────────────────────────────
+add('D', 'list_resources language_code=en', 'list_resources_for_language', { language_code: 'en' }, 'has', { needle: 'en' });
+add('D', 'list_resources lang=en', 'list_resources_for_language', { lang: 'en' }, 'has', { needle: 'en' });
+add('D', 'notes language_code=en John 3:16', 'fetch_translation_notes', { reference: 'John 3:16', language_code: 'en' }, 'data', { minItems: 1 });
+
+// ── Class H: weird arg containers ────────────────────────────────────────
+add('H', 'list_languages args=[]', 'list_languages', [], 'ok');
+add('H', 'list_languages args=null', 'list_languages', null, 'ok');
+add('H', 'list_subjects args=[]', 'list_subjects', [], 'ok');
+
+// ── Controls / regression (must keep working) ────────────────────────────
+add('CTRL', 'notes John 3:16', 'fetch_translation_notes', { reference: 'John 3:16', language: 'en' }, 'data', { minItems: 1 });
+add('CTRL', 'notes Mark 9:1 (single-digit)', 'fetch_translation_notes', { reference: 'Mark 9:1', language: 'en' }, 'data', { minItems: 1 });
+add('CTRL', 'notes Titus 1:1', 'fetch_translation_notes', { reference: 'Titus 1:1', language: 'en' }, 'data', { minItems: 1 });
+add('CTRL', 'scripture John 3:16', 'fetch_scripture', { reference: 'John 3:16', language: 'en' }, 'has', { needle: 'John' });
+add('CTRL', 'scripture James 1:13-15 (long name)', 'fetch_scripture', { reference: 'James 1:13-15', language: 'en' }, 'has', { needle: 'James' });
+add('CTRL', 'scripture 1 Corinthians 13:4-7', 'fetch_scripture', { reference: '1 Corinthians 13:4-7', language: 'en' }, 'ok');
+add('CTRL', 'word path=bible/kt/love (canonical)', 'fetch_translation_word', { path: 'bible/kt/love', language: 'en' }, 'has', { needle: 'love' });
+add('CTRL', 'academy path=translate/figs-metaphor', 'fetch_translation_academy', { path: 'translate/figs-metaphor', language: 'en' }, 'has', { needle: 'etaphor' });
+add('CTRL', 'word_links John 3:16', 'fetch_translation_word_links', { reference: 'John 3:16', language: 'en' }, 'data', { minItems: 1 });
+// Localized (Spanish) book name resolves through the parser. NOTE: the *accented*
+// form "Génesis" is rejected by a separate pre-existing `reference` param validator
+// (confirmed identical on prod) — out of scope for #24, tracked separately.
+add('CTRL', 'notes Marcos 1:1 (es localized name)', 'fetch_translation_notes', { reference: 'Marcos 1:1', language: 'es' }, 'resolves');
+
+async function callTool(tool, args) {
+	const res = await fetch(endpoint, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+		body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: tool, arguments: args } })
+	});
+	const text = await res.text();
+	try {
+		return JSON.parse(text);
+	} catch {
+		const m = text.match(/data:\s*(\{.*\})/s);
+		return m ? JSON.parse(m[1]) : { raw: text };
+	}
+}
+function resultText(parsed) {
+	const c = parsed?.result?.content;
+	return Array.isArray(c) ? c.map((x) => x?.text ?? '').join('\n') : '';
+}
+function countItems(text) {
+	try {
+		const o = JSON.parse(text);
+		for (const f of ['items', 'verseNotes', 'notes', 'questions', 'translationQuestions', 'scripture', 'scriptures'])
+			if (Array.isArray(o?.[f])) return o[f].length;
+		if (o?.content || o?.definition || o?.text) return 1;
+		return 0;
+	} catch {
+		return text.trim() ? 1 : 0;
+	}
+}
+const PARSE_REJECTION =
+	/invalid bible reference|invalid book reference|invalid reference format|missing required parameter|could not (parse|determine)|expected record/i;
+
+function evaluate(c, parsed) {
+	const err = parsed?.error;
+	const text = resultText(parsed);
+	if (c.kind === 'error') return { pass: !!err, detail: err ? 'error (expected)' : 'no error' };
+	if (c.kind === 'resolves') {
+		if (!err) return { pass: true, detail: 'resolved' };
+		const msg = String(err.message || '');
+		if (PARSE_REJECTION.test(msg)) return { pass: false, detail: `parse-rejected: ${msg.slice(0, 80)}` };
+		return { pass: true, detail: `resolved (no-data)` };
+	}
+	if (err) return { pass: false, detail: `ERR: ${String(err.message).slice(0, 90)}` };
+	if (c.kind === 'has') {
+		const ok = text.toLowerCase().includes(String(c.needle).toLowerCase());
+		return { pass: ok, detail: ok ? `has "${c.needle}"` : `missing "${c.needle}"` };
+	}
+	if (c.kind === 'data') {
+		const n = countItems(text);
+		return { pass: n >= (c.minItems ?? 1), detail: `${n} item(s)` };
+	}
+	// ok
+	return { pass: text.trim().length > 0, detail: text.trim() ? 'ok' : 'empty' };
+}
+
+async function run() {
+	console.log(`\nHEAVY smoke → ${endpoint}  (${cases.length} cases, conc=${CONC})\n${'─'.repeat(70)}`);
+	const results = new Array(cases.length);
+	let idx = 0;
+	async function worker() {
+		while (idx < cases.length) {
+			const i = idx++;
+			const c = cases[i];
+			try {
+				const parsed = await callTool(c.tool, c.args);
+				const r = evaluate(c, parsed);
+				results[i] = { c, ...r };
+			} catch (e) {
+				results[i] = { c, pass: false, detail: `threw: ${e.message}` };
+			}
+			const r = results[i];
+			if (!r.pass) console.log(`FAIL [${c.cls}] ${c.name} — ${r.detail}`);
+		}
+	}
+	await Promise.all(Array.from({ length: CONC }, worker));
+
+	const byCls = {};
+	for (const r of results) {
+		const k = r.c.cls;
+		byCls[k] = byCls[k] || { pass: 0, total: 0 };
+		byCls[k].total++;
+		if (r.pass) byCls[k].pass++;
+	}
+	console.log('─'.repeat(70));
+	console.log('Per-class:');
+	for (const k of Object.keys(byCls).sort())
+		console.log(`  ${k.padEnd(5)} ${byCls[k].pass}/${byCls[k].total}`);
+	const passed = results.filter((r) => r.pass).length;
+	console.log('─'.repeat(70));
+	console.log(`TOTAL ${passed}/${results.length}`);
+	process.exit(passed === results.length ? 0 : 1);
+}
+run();

--- a/scripts/issue24-parser-probe.mts
+++ b/scripts/issue24-parser-probe.mts
@@ -1,0 +1,59 @@
+/**
+ * Local probe for src/functions/reference-parser.ts (notes/questions/word-links parser).
+ * Verifies issue #24 Class A: multi-digit chapters + invalid/spaceless codes,
+ * with controls that must keep resolving.
+ */
+import { parseReference } from '../src/functions/reference-parser.js';
+
+type Row = { input: string; wantBook: string | null; wantChapter?: number; wantVerse?: number };
+
+const ROWS: Row[] = [
+	// multi-digit (item 1)
+	{ input: 'Mark 10:25', wantBook: 'MRK', wantChapter: 10, wantVerse: 25 },
+	{ input: 'Matthew 13:55', wantBook: 'MAT', wantChapter: 13, wantVerse: 55 },
+	{ input: 'Genesis 50:1', wantBook: 'GEN', wantChapter: 50, wantVerse: 1 },
+	{ input: 'Psalms 119:1', wantBook: 'PSA', wantChapter: 119, wantVerse: 1 },
+	{ input: 'Mark 10', wantBook: 'MRK', wantChapter: 10 },
+	// invalid / spaceless codes
+	{ input: 'MAR 10:25', wantBook: 'MRK', wantChapter: 10, wantVerse: 25 },
+	{ input: '2KI 12:8', wantBook: '2KI', wantChapter: 12, wantVerse: 8 },
+	{ input: '2KGS 12:8', wantBook: '2KI', wantChapter: 12, wantVerse: 8 },
+	{ input: '1KGS 8:1', wantBook: '1KI', wantChapter: 8, wantVerse: 1 },
+	{ input: '1Co 15:58', wantBook: '1CO', wantChapter: 15, wantVerse: 58 },
+	{ input: '1CO 15:58', wantBook: '1CO', wantChapter: 15, wantVerse: 58 },
+	{ input: '1 Corinthians 13:4-7', wantBook: '1CO', wantChapter: 13, wantVerse: 4 },
+	// controls (single-digit + book-only + numbered with space)
+	{ input: 'John 3:16', wantBook: 'JHN', wantChapter: 3, wantVerse: 16 },
+	{ input: 'Mark 9:1', wantBook: 'MRK', wantChapter: 9, wantVerse: 1 },
+	{ input: '2 Kings 12:8', wantBook: '2KI', wantChapter: 12, wantVerse: 8 },
+	{ input: 'Philemon', wantBook: 'PHM', wantChapter: 1 },
+	{ input: 'Titus 1-2', wantBook: 'TIT', wantChapter: 1 },
+	{ input: 'Génesis 1:1', wantBook: 'GEN', wantChapter: 1, wantVerse: 1 },
+	// negative control: should NOT resolve to a book
+	{ input: 'definitely not a reference 99', wantBook: null }
+];
+
+let pass = 0;
+for (const r of ROWS) {
+	const parsed = parseReference(r.input, { language: r.input.startsWith('Génesis') ? 'es' : undefined });
+	let ok: boolean;
+	let detail: string;
+	if (r.wantBook === null) {
+		ok = parsed === null || parsed.book === '' || parsed.book === undefined;
+		detail = parsed ? `book=${parsed.book}` : 'null';
+	} else if (!parsed) {
+		ok = false;
+		detail = 'null';
+	} else {
+		ok =
+			parsed.book === r.wantBook &&
+			(r.wantChapter === undefined || parsed.chapter === r.wantChapter) &&
+			(r.wantVerse === undefined || parsed.verse === r.wantVerse);
+		detail = `${parsed.book} ${parsed.chapter ?? ''}:${parsed.verse ?? ''}`;
+	}
+	if (ok) pass++;
+	console.log(`${ok ? 'PASS' : 'FAIL'}  ${r.input.padEnd(30)} → ${detail}`);
+}
+console.log('─'.repeat(50));
+console.log(`${pass}/${ROWS.length} passed`);
+process.exit(pass === ROWS.length ? 0 : 1);

--- a/scripts/issue24-schema-probe.mts
+++ b/scripts/issue24-schema-probe.mts
@@ -28,9 +28,29 @@ for (const t of ['fetch_scripture', 'fetch_translation_notes', 'fetch_translatio
 		fail++;
 	}
 }
-// path tools: aliases present
-check('fetch_translation_word', ['path', 'term', 'word', 'name', 'article', 'moduleId', 'identifier']);
-check('fetch_translation_academy', ['path', 'term', 'name', 'article', 'moduleId', 'identifier']);
+// path tools: aliases present (incl. language aliases)
+check('fetch_translation_word', ['path', 'term', 'word', 'name', 'article', 'moduleId', 'identifier', 'language_code', 'languageCode', 'lang']);
+check('fetch_translation_academy', ['path', 'term', 'name', 'article', 'moduleId', 'identifier', 'language_code', 'languageCode', 'lang']);
+
+// required-language tool: language must be optional + aliases advertised (Class D DoD shape)
+check('list_resources_for_language', ['language', 'language_code', 'languageCode', 'lang']);
+{
+	const s: any = zodToJsonSchema(tools['list_resources_for_language'].inputSchema, { $refStrategy: 'none' });
+	if ((s.required || []).includes('language')) {
+		console.log('   FAIL: list_resources_for_language still requires `language`');
+		fail++;
+	}
+}
+check('list_subjects', ['language_code', 'languageCode', 'lang']);
+
+// No tool may advertise additionalProperties:false (handler tolerates extras everywhere).
+for (const name of Object.keys(tools)) {
+	const s: any = zodToJsonSchema(tools[name].inputSchema, { $refStrategy: 'none' });
+	if (s.additionalProperties === false) {
+		console.log(`FAIL  ${name}: additionalProperties === false`);
+		fail++;
+	}
+}
 
 console.log('\n' + (fail ? `${fail} FAILURES` : 'ALL SCHEMA CHECKS PASS'));
 process.exit(fail ? 1 : 0);

--- a/scripts/issue24-schema-probe.mts
+++ b/scripts/issue24-schema-probe.mts
@@ -1,0 +1,36 @@
+/** Verify the advertised tools/list JSON Schema matches the tolerant behavior (issue #24 review). */
+import { getMCPToolDefinitions } from '../src/mcp/tools-registry.js';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+const tools = Object.fromEntries(getMCPToolDefinitions().map((t) => [t.name, t]));
+let fail = 0;
+function check(name: string, wantProps: string[]) {
+	const s: any = zodToJsonSchema(tools[name].inputSchema, { $refStrategy: 'none' });
+	const props = Object.keys(s.properties || {});
+	const addl = s.additionalProperties;
+	const required = s.required || [];
+	const missing = wantProps.filter((p) => !props.includes(p));
+	const additionalOk = addl !== false; // must NOT be false
+	const ok = missing.length === 0 && additionalOk;
+	if (!ok) fail++;
+	console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}`);
+	console.log(`   additionalProperties=${addl} required=${JSON.stringify(required)}`);
+	console.log(`   props=${props.join(',')}`);
+	if (missing.length) console.log(`   MISSING: ${missing.join(',')}`);
+}
+
+// reference tools: reference must be optional (not in required), decomposed + language_code present
+for (const t of ['fetch_scripture', 'fetch_translation_notes', 'fetch_translation_questions', 'fetch_translation_word_links']) {
+	check(t, ['reference', 'book', 'chapter', 'verse', 'endVerse', 'language_code']);
+	const s: any = zodToJsonSchema(tools[t].inputSchema, { $refStrategy: 'none' });
+	if ((s.required || []).includes('reference')) {
+		console.log(`   FAIL: reference still required`);
+		fail++;
+	}
+}
+// path tools: aliases present
+check('fetch_translation_word', ['path', 'term', 'word', 'name', 'article', 'moduleId', 'identifier']);
+check('fetch_translation_academy', ['path', 'term', 'name', 'article', 'moduleId', 'identifier']);
+
+console.log('\n' + (fail ? `${fail} FAILURES` : 'ALL SCHEMA CHECKS PASS'));
+process.exit(fail ? 1 : 0);

--- a/src/functions/reference-parser.ts
+++ b/src/functions/reference-parser.ts
@@ -76,11 +76,13 @@ const BOOK_MAPPINGS: Record<string, { code: string; name: string }> = {
   // 1 Kings
   "1kings": { code: "1KI", name: "1 Kings" },
   "1ki": { code: "1KI", name: "1 Kings" },
+  "1kgs": { code: "1KI", name: "1 Kings" }, // common invalid LLM code → 1KI
   "1k": { code: "1KI", name: "1 Kings" },
 
   // 2 Kings
   "2kings": { code: "2KI", name: "2 Kings" },
   "2ki": { code: "2KI", name: "2 Kings" },
+  "2kgs": { code: "2KI", name: "2 Kings" }, // common invalid LLM code → 2KI
   "2k": { code: "2KI", name: "2 Kings" },
 
   // 1 Chronicles
@@ -390,8 +392,18 @@ const BOOK_MAPPINGS: Record<string, { code: string; name: string }> = {
   romains: { code: "ROM", name: "Romans" },
 };
 
-/** Book title: optional "1/2/3 " prefix + word starting with a letter (incl. accents) + rest */
-const BOOK_HEAD = "(?:[1-3]\\s+)?[\\p{L}][\\p{L}0-9\\s\\.'’\\-]*";
+/** Book title: optional "1/2/3" prefix (space optional) + word starting with a letter (incl. accents) + rest */
+// NOTE 1: The trailing character class must NOT include digits. Bible book names
+// never contain interior digits (numbered books use the leading `[1-3]\s*`), and
+// allowing 0-9 here let the greedy book-head absorb the first chapter digit of a
+// multi-digit chapter (e.g. "Mark 10:25" -> book "Mark 1", chapter "0"), which
+// then failed the `chapter < 1` guard and made parseReference() return null for
+// every chapter >= 10. That surfaced as bogus "Invalid reference format" errors
+// on translation notes/questions for the majority of the Bible. See issue #24.
+// NOTE 2: The numbered-book prefix uses `\s*` (not `\s+`) so spaceless codes the
+// LLM emits — "2KI", "1Co", "1Jn" — parse the same as "2 Kings"/"1 Corinthians".
+// resolveBookInfo() strips spaces before lookup, so "2KI"/"2 Ki" both resolve.
+const BOOK_HEAD = "(?:[1-3]\\s*)?[\\p{L}][\\p{L}\\s\\.'’\\-]*";
 
 function resolveBookInfo(
   bookStr: string,

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -32,6 +32,58 @@ const REFERENCE_INPUT_DESCRIPTION =
   "You may also send the parts separately as book + chapter + verse and they will be combined into one reference.";
 
 /**
+ * Tolerated-argument fields advertised on the input schemas (issue #24).
+ *
+ * The server normalizes these to the canonical fields in
+ * `UnifiedMCPHandler.normalizeArgs()` before validation. They are advertised
+ * here — optional, plus `.passthrough()` on each tool so the generated JSON
+ * Schema does NOT set `additionalProperties: false` — so schema-aware MCP
+ * clients are not blocked from sending the exact shapes the server accepts.
+ * The canonical fields (`reference`, `path`) remain the documented preference.
+ */
+const intOrString = () => z.union([z.string(), z.number()]);
+
+/** Reference tools: decomposed book/chapter/verse + `language_code`; `reference` becomes optional. */
+const REFERENCE_TOLERANCE_FIELDS = {
+  reference: z.string().optional().describe(REFERENCE_INPUT_DESCRIPTION),
+  book: z
+    .string()
+    .optional()
+    .describe(
+      "Decomposed reference: book (USFM code or English/localized name). Combined with chapter/verse into a single `reference`. Prefer sending the whole `reference` string instead.",
+    ),
+  chapter: intOrString()
+    .optional()
+    .describe("Decomposed reference: chapter number."),
+  verse: intOrString()
+    .optional()
+    .describe("Decomposed reference: verse number."),
+  endVerse: intOrString()
+    .optional()
+    .describe("Decomposed reference: end verse for a range."),
+  language_code: z
+    .string()
+    .optional()
+    .describe("Alias for `language` (BCP-47 tag)."),
+};
+
+/** Word/Academy tools: the `path` synonyms the server accepts and normalizes. */
+const PATH_TOLERANCE_FIELDS = {
+  term: z
+    .string()
+    .optional()
+    .describe(
+      "Alias for `path` — a plain term/module name resolved across categories.",
+    ),
+  word: z.string().optional().describe("Alias for `path`."),
+  name: z.string().optional().describe("Alias for `path`."),
+  article: z.string().optional().describe("Alias for `path`."),
+  moduleId: z.string().optional().describe("Alias for `path`."),
+  module: z.string().optional().describe("Alias for `path`."),
+  identifier: z.string().optional().describe("Alias for `path`."),
+};
+
+/**
  * MCP Tool Definition
  */
 export interface MCPToolDefinition {
@@ -53,9 +105,9 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
         "The required argument is `reference` as a full passage string (book + chapter/verse, not a book code alone). " +
         "Book may be USFM (JHN) or a full/localized title that matches the `language` parameter. " +
         "Examples: JHN 3:16, John 3:16, GEN 1:1-3, MAT 5. Door43 catalog owners are discovered automatically (all-org search).",
-      inputSchema: FetchScriptureArgs.omit({ reference: true }).extend({
-        reference: z.string().describe(REFERENCE_INPUT_DESCRIPTION),
-      }),
+      inputSchema: FetchScriptureArgs.omit({ reference: true })
+        .extend(REFERENCE_TOLERANCE_FIELDS)
+        .passthrough(),
     },
     {
       name: "fetch_translation_notes",
@@ -64,9 +116,9 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
         "Returns verseNotes (verse-specific) and contextNotes (book/chapter background) separately. " +
         "Pass `reference` as a full passage (book + chapter/verse or range), not a standalone book code. " +
         "USFM or localized book names are fine when they match `language`. All Door43 organizations are searched automatically.",
-      inputSchema: FetchTranslationNotesArgs.omit({ reference: true }).extend({
-        reference: z.string().describe(REFERENCE_INPUT_DESCRIPTION),
-      }),
+      inputSchema: FetchTranslationNotesArgs.omit({ reference: true })
+        .extend(REFERENCE_TOLERANCE_FIELDS)
+        .passthrough(),
     },
     {
       name: "fetch_translation_questions",
@@ -74,11 +126,9 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
         "Fetch comprehension questions with answers to verify translation accuracy. " +
         "Pass `reference` as a full passage (book + chapter/verse or range), not a book code by itself. " +
         "All Door43 organizations are searched automatically.",
-      inputSchema: FetchTranslationQuestionsArgs.omit({
-        reference: true,
-      }).extend({
-        reference: z.string().describe(REFERENCE_INPUT_DESCRIPTION),
-      }),
+      inputSchema: FetchTranslationQuestionsArgs.omit({ reference: true })
+        .extend(REFERENCE_TOLERANCE_FIELDS)
+        .passthrough(),
     },
     {
       name: "fetch_translation_word_links",
@@ -86,11 +136,9 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
         "Fetch key biblical terms in a passage (e.g. grace, faith) with links to term articles. " +
         "Pass `reference` as a full passage (book + chapter/verse or range), not a book code by itself. " +
         "All Door43 organizations are searched automatically.",
-      inputSchema: FetchTranslationWordLinksArgs.omit({
-        reference: true,
-      }).extend({
-        reference: z.string().describe(REFERENCE_INPUT_DESCRIPTION),
-      }),
+      inputSchema: FetchTranslationWordLinksArgs.omit({ reference: true })
+        .extend(REFERENCE_TOLERANCE_FIELDS)
+        .passthrough(),
     },
     {
       name: "fetch_translation_word",
@@ -99,7 +147,9 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
         'Identify the term with `path` — preferably the value from `externalReference` in a fetch_translation_word_links response (e.g. "bible/kt/love") — ' +
         'but a plain term name also works: send `path: "love"`, or `term`/`word: "love"` and it is resolved across all categories (kt/names/other). ' +
         "No file extensions.",
-      inputSchema: GetTranslationWordArgs,
+      inputSchema: GetTranslationWordArgs.extend(
+        PATH_TOLERANCE_FIELDS,
+      ).passthrough(),
     },
     {
       name: "fetch_translation_academy",
@@ -108,7 +158,9 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
         'Identify the article with `path` — preferably the value from `externalReference` in a fetch_translation_notes response (e.g. "translate/figs-metaphor") — ' +
         'but a plain module id also works: send `path: "figs-metaphor"`, or `term`/`moduleId: "figs-metaphor"` and it is resolved across categories. ' +
         "No file extensions.",
-      inputSchema: FetchTranslationAcademyArgs,
+      inputSchema: FetchTranslationAcademyArgs.extend(
+        PATH_TOLERANCE_FIELDS,
+      ).passthrough(),
     },
     {
       name: "list_tools",

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -27,7 +27,9 @@ import { ListResourcesForLanguageArgs } from "../tools/listResourcesForLanguage.
 const REFERENCE_INPUT_DESCRIPTION =
   "Full Bible passage in one string: the book (USFM 3-letter code like JHN, or the book title in English or the request language, e.g. John, Juan, Génesis) plus chapter and verse or verse range, or a whole chapter. " +
   "This is not only a book code — a bare code with no chapter/verse (e.g. only 'JHN') is wrong. " +
-  'Valid examples: "JHN 3:16", "John 3:16", "Juan 3:16" (use language: es), "GEN 1:1-3", "MAT 5" (entire chapter).';
+  'Valid examples: "JHN 3:16", "John 3:16", "Juan 3:16" (use language: es), "GEN 1:1-3", "MAT 5" (entire chapter), "1 Corinthians 13:4-7". ' +
+  'Full English/localized book names and multi-digit chapters (e.g. "Mark 10:25") are accepted. ' +
+  "You may also send the parts separately as book + chapter + verse and they will be combined into one reference.";
 
 /**
  * MCP Tool Definition
@@ -93,13 +95,19 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
     {
       name: "fetch_translation_word",
       description:
-        "Fetch dictionary entries for biblical terms by name (e.g., 'grace', 'paul', 'covenant'), path, or Bible reference.",
+        "Fetch the dictionary article for a biblical term (e.g. grace, love, Abraham, covenant). " +
+        'Identify the term with `path` — preferably the value from `externalReference` in a fetch_translation_word_links response (e.g. "bible/kt/love") — ' +
+        'but a plain term name also works: send `path: "love"`, or `term`/`word: "love"` and it is resolved across all categories (kt/names/other). ' +
+        "No file extensions.",
       inputSchema: GetTranslationWordArgs,
     },
     {
       name: "fetch_translation_academy",
       description:
-        "Fetch Translation Academy training articles teaching translation principles, methods, and techniques.",
+        "Fetch Translation Academy training articles teaching translation principles, methods, and techniques. " +
+        'Identify the article with `path` — preferably the value from `externalReference` in a fetch_translation_notes response (e.g. "translate/figs-metaphor") — ' +
+        'but a plain module id also works: send `path: "figs-metaphor"`, or `term`/`moduleId: "figs-metaphor"` and it is resolved across categories. ' +
+        "No file extensions.",
       inputSchema: FetchTranslationAcademyArgs,
     },
     {

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -43,7 +43,20 @@ const REFERENCE_INPUT_DESCRIPTION =
  */
 const intOrString = () => z.union([z.string(), z.number()]);
 
-/** Reference tools: decomposed book/chapter/verse + `language_code`; `reference` becomes optional. */
+/**
+ * Language synonyms the handler normalizes to `language` for EVERY tool
+ * (issue #24 Class D). Advertised on every tool that takes `language`.
+ */
+const LANGUAGE_ALIAS_FIELDS = {
+  language_code: z
+    .string()
+    .optional()
+    .describe("Alias for `language` (BCP-47 tag)."),
+  languageCode: z.string().optional().describe("Alias for `language`."),
+  lang: z.string().optional().describe("Alias for `language`."),
+};
+
+/** Reference tools: decomposed book/chapter/verse + language aliases; `reference` becomes optional. */
 const REFERENCE_TOLERANCE_FIELDS = {
   reference: z.string().optional().describe(REFERENCE_INPUT_DESCRIPTION),
   book: z
@@ -61,10 +74,7 @@ const REFERENCE_TOLERANCE_FIELDS = {
   endVerse: intOrString()
     .optional()
     .describe("Decomposed reference: end verse for a range."),
-  language_code: z
-    .string()
-    .optional()
-    .describe("Alias for `language` (BCP-47 tag)."),
+  ...LANGUAGE_ALIAS_FIELDS,
 };
 
 /** Word/Academy tools: the `path` synonyms the server accepts and normalizes. */
@@ -147,9 +157,10 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
         'Identify the term with `path` — preferably the value from `externalReference` in a fetch_translation_word_links response (e.g. "bible/kt/love") — ' +
         'but a plain term name also works: send `path: "love"`, or `term`/`word: "love"` and it is resolved across all categories (kt/names/other). ' +
         "No file extensions.",
-      inputSchema: GetTranslationWordArgs.extend(
-        PATH_TOLERANCE_FIELDS,
-      ).passthrough(),
+      inputSchema: GetTranslationWordArgs.extend({
+        ...PATH_TOLERANCE_FIELDS,
+        ...LANGUAGE_ALIAS_FIELDS,
+      }).passthrough(),
     },
     {
       name: "fetch_translation_academy",
@@ -158,33 +169,42 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
         'Identify the article with `path` — preferably the value from `externalReference` in a fetch_translation_notes response (e.g. "translate/figs-metaphor") — ' +
         'but a plain module id also works: send `path: "figs-metaphor"`, or `term`/`moduleId: "figs-metaphor"` and it is resolved across categories. ' +
         "No file extensions.",
-      inputSchema: FetchTranslationAcademyArgs.extend(
-        PATH_TOLERANCE_FIELDS,
-      ).passthrough(),
+      inputSchema: FetchTranslationAcademyArgs.extend({
+        ...PATH_TOLERANCE_FIELDS,
+        ...LANGUAGE_ALIAS_FIELDS,
+      }).passthrough(),
     },
     {
       name: "list_tools",
       description:
         "List all available MCP tools with their schemas and descriptions. Use this to discover what translation helps tools are available.",
-      inputSchema: z.object({}).describe("No parameters required"),
+      // passthrough so additionalProperties is not false (the handler tolerates extra args on every tool)
+      inputSchema: z
+        .object({})
+        .passthrough()
+        .describe("No parameters required"),
     },
     {
       name: "list_languages",
       description:
         "List available Bible translation languages with codes and names. All Door43 organizations are searched automatically.",
-      inputSchema: ListLanguagesArgs,
+      inputSchema: ListLanguagesArgs.passthrough(),
     },
     {
       name: "list_subjects",
       description:
         "List available resource types (Bibles, notes, questions, terms, training) to discover what translation helps exist.",
-      inputSchema: ListSubjectsArgs,
+      inputSchema: ListSubjectsArgs.extend(LANGUAGE_ALIAS_FIELDS).passthrough(),
     },
     {
       name: "list_resources_for_language",
       description:
         "List all translation resources for a specific language organized by type. Automatically falls back to language variants if base language has no resources (e.g., 'es' → 'es-419'). Recommended workflow: 1) list_languages to find codes, 2) this tool to see available resources, 3) fetch tools to get content.",
-      inputSchema: ListResourcesForLanguageArgs,
+      // `language` is required by the handler, but `language_code`/`languageCode`/`lang`
+      // are normalized to it first — so advertise it as optional with the aliases.
+      inputSchema: ListResourcesForLanguageArgs.partial({ language: true })
+        .extend(LANGUAGE_ALIAS_FIELDS)
+        .passthrough(),
     },
   ];
 }

--- a/ui/src/lib/mcp/UnifiedMCPHandler.ts
+++ b/ui/src/lib/mcp/UnifiedMCPHandler.ts
@@ -147,9 +147,11 @@ export class UnifiedMCPHandler {
 		// value is passed through verbatim as the path.
 		if (requiredParams.includes('path')) {
 			if (isBlank(args.path)) {
-				// `topic` is last: it's a legitimate filter on these tools, so only
-				// fall back to it when no clearer synonym is present.
-				for (const k of ['term', 'word', 'moduleId', 'module', 'topic']) {
+				// Synonyms observed in prod logs the model sends instead of `path`:
+				// term / word / name (issue #24). `topic` is last — it's a legitimate
+				// filter on these tools, so only fall back to it when nothing clearer
+				// is present.
+				for (const k of ['term', 'word', 'name', 'moduleId', 'module', 'topic']) {
 					if (!isBlank(args[k])) {
 						args.path = String(args[k]).trim();
 						if (k === 'topic') delete args.topic; // consumed the filter as the path
@@ -160,7 +162,7 @@ export class UnifiedMCPHandler {
 			}
 			// `term` is a deprecated endpoint param (rejected downstream); the other
 			// synonyms aren't endpoint params either — drop any we didn't consume.
-			for (const k of ['term', 'word', 'moduleId', 'module']) delete args[k];
+			for (const k of ['term', 'word', 'name', 'moduleId', 'module']) delete args[k];
 		}
 
 		return args;

--- a/ui/src/lib/mcp/UnifiedMCPHandler.ts
+++ b/ui/src/lib/mcp/UnifiedMCPHandler.ts
@@ -5,6 +5,45 @@
 
 import { ToolRegistry, type MCPToolResponse } from '../../../../src/contracts/ToolContracts';
 
+/** True for values an LLM may send for "no value": undefined, null, or empty/blank string. */
+function isBlank(v: unknown): boolean {
+	return v === undefined || v === null || (typeof v === 'string' && v.trim() === '');
+}
+
+/** Return the first non-blank value, or undefined if all are blank. */
+function firstNonBlank(...vals: unknown[]): unknown {
+	for (const v of vals) {
+		if (!isBlank(v)) return v;
+	}
+	return undefined;
+}
+
+/**
+ * Assemble a single `reference` string from decomposed book/chapter/verse args
+ * (issue #24 Class C). The model sometimes sends {book,chapter,verse} instead of
+ * one reference; the endpoints only accept a reference string.
+ */
+function assembleReference(a: Record<string, any>): string {
+	const book = String(a.book).trim();
+	const chapter = firstNonBlank(a.chapter, a.startChapter, a.start_chapter);
+	const verse = firstNonBlank(a.verse, a.startVerse, a.start_verse);
+	const endVerse = firstNonBlank(a.endVerse, a.end_verse);
+	const endChapter = firstNonBlank(a.endChapter, a.end_chapter);
+
+	let ref = book;
+	if (!isBlank(chapter)) {
+		ref += ` ${String(chapter).trim()}`;
+		if (!isBlank(verse)) {
+			ref += `:${String(verse).trim()}`;
+			if (!isBlank(endVerse)) ref += `-${String(endVerse).trim()}`;
+		} else if (!isBlank(endChapter)) {
+			// Whole-chapter range, e.g. {book:"Titus",chapter:1,endChapter:2} → "Titus 1-2"
+			ref += `-${String(endChapter).trim()}`;
+		}
+	}
+	return ref;
+}
+
 /** Build a readable message from JSON error bodies (e.g. simpleEndpoint 400 responses). */
 function formatEndpointFailureMessage(status: number, body: unknown): string {
 	const base = `Tool endpoint failed: ${status}`;
@@ -42,24 +81,113 @@ export class UnifiedMCPHandler {
 	}
 
 	/**
+	 * Normalize LLM-generated tool arguments into the shape the endpoints expect.
+	 *
+	 * Issue #24: ~90% of production tool-call errors are strict validation
+	 * rejecting recoverable input. The worker forwards model arguments verbatim,
+	 * so this dispatch chokepoint is the single place to be liberal in what we
+	 * accept (Postel's law). Every transform is additive and only fires when the
+	 * canonical field is absent, so well-formed calls pass through untouched.
+	 *
+	 * - Class H: args arriving as null / an array / a non-object → {}
+	 * - Class D: language_code / languageCode / lang → language
+	 * - Class C: decomposed book + chapter + verse → a single `reference`
+	 * - Class B: term / word / moduleId / topic → `path` (for path-required tools)
+	 */
+	private normalizeArgs(
+		toolName: string,
+		requiredParams: string[],
+		rawArgs: any
+	): Record<string, any> {
+		// Class H — coerce any non-plain-object container to an empty object.
+		const args: Record<string, any> =
+			rawArgs && typeof rawArgs === 'object' && !Array.isArray(rawArgs) ? { ...rawArgs } : {};
+
+		// Class D — language synonyms → language.
+		if (isBlank(args.language)) {
+			const langAlias = firstNonBlank(args.language_code, args.languageCode, args.lang);
+			if (langAlias !== undefined) {
+				args.language = langAlias;
+				console.log(`[UNIFIED HANDLER] Aliased language for ${toolName}:`, langAlias);
+			}
+		}
+		delete args.language_code;
+		delete args.languageCode;
+		delete args.lang;
+
+		// Class C — decomposed book/chapter/verse → reference (only for ref tools).
+		if (requiredParams.includes('reference') && isBlank(args.reference) && !isBlank(args.book)) {
+			args.reference = assembleReference(args);
+			console.log(
+				`[UNIFIED HANDLER] Assembled reference for ${toolName} from decomposed args:`,
+				args.reference
+			);
+		}
+		if (!isBlank(args.reference)) {
+			// Strip decomposed leftovers so they don't leak into the query string.
+			for (const k of [
+				'book',
+				'chapter',
+				'verse',
+				'startChapter',
+				'start_chapter',
+				'startVerse',
+				'start_verse',
+				'endVerse',
+				'end_verse',
+				'endChapter',
+				'end_chapter'
+			]) {
+				delete args[k];
+			}
+		}
+
+		// Class B — term/word synonyms → bare `path` (path-required tools only).
+		// The endpoints resolve a bare term across all categories, so the synonym
+		// value is passed through verbatim as the path.
+		if (requiredParams.includes('path')) {
+			if (isBlank(args.path)) {
+				// `topic` is last: it's a legitimate filter on these tools, so only
+				// fall back to it when no clearer synonym is present.
+				for (const k of ['term', 'word', 'moduleId', 'module', 'topic']) {
+					if (!isBlank(args[k])) {
+						args.path = String(args[k]).trim();
+						if (k === 'topic') delete args.topic; // consumed the filter as the path
+						console.log(`[UNIFIED HANDLER] Aliased path for ${toolName} from ${k}:`, args.path);
+						break;
+					}
+				}
+			}
+			// `term` is a deprecated endpoint param (rejected downstream); the other
+			// synonyms aren't endpoint params either — drop any we didn't consume.
+			for (const k of ['term', 'word', 'moduleId', 'module']) delete args[k];
+		}
+
+		return args;
+	}
+
+	/**
 	 * Handle any MCP tool call consistently
 	 */
-	async handleToolCall(toolName: string, args: any): Promise<MCPToolResponse> {
+	async handleToolCall(toolName: string, rawArgs: any): Promise<MCPToolResponse> {
 		const tool = ToolRegistry[toolName as keyof typeof ToolRegistry];
 
 		if (!tool) {
 			throw new Error(`Unknown tool: ${toolName}`);
 		}
 
-		// Log received parameters (before defaults are applied)
+		// Log received parameters (before normalization / defaults)
 		console.log(
 			`[UNIFIED HANDLER] Received parameters for ${toolName}:`,
-			JSON.stringify(args, null, 2)
+			JSON.stringify(rawArgs, null, 2)
 		);
+
+		// Normalize LLM-generated arguments (issue #24 tolerance) before validation.
+		const args = this.normalizeArgs(toolName, tool.requiredParams, rawArgs);
 
 		// Validate required parameters
 		for (const param of tool.requiredParams) {
-			if (!args[param]) {
+			if (isBlank(args[param])) {
 				throw new Error(`Missing required parameter: ${param}`);
 			}
 		}

--- a/ui/src/lib/mcp/UnifiedMCPHandler.ts
+++ b/ui/src/lib/mcp/UnifiedMCPHandler.ts
@@ -147,11 +147,20 @@ export class UnifiedMCPHandler {
 		// value is passed through verbatim as the path.
 		if (requiredParams.includes('path')) {
 			if (isBlank(args.path)) {
-				// Synonyms observed in prod logs the model sends instead of `path`:
-				// term / word / name (issue #24). `topic` is last — it's a legitimate
-				// filter on these tools, so only fall back to it when nothing clearer
-				// is present.
-				for (const k of ['term', 'word', 'name', 'moduleId', 'module', 'topic']) {
+				// Synonyms observed in prod/staging logs the model sends instead of
+				// `path`: term / word / name / article / moduleId / identifier
+				// (issue #24). `topic` is last — it's a legitimate filter on these
+				// tools, so only fall back to it when nothing clearer is present.
+				for (const k of [
+					'term',
+					'word',
+					'name',
+					'article',
+					'moduleId',
+					'module',
+					'identifier',
+					'topic'
+				]) {
 					if (!isBlank(args[k])) {
 						args.path = String(args[k]).trim();
 						if (k === 'topic') delete args.topic; // consumed the filter as the path
@@ -162,7 +171,8 @@ export class UnifiedMCPHandler {
 			}
 			// `term` is a deprecated endpoint param (rejected downstream); the other
 			// synonyms aren't endpoint params either — drop any we didn't consume.
-			for (const k of ['term', 'word', 'name', 'moduleId', 'module']) delete args[k];
+			for (const k of ['term', 'word', 'name', 'article', 'moduleId', 'module', 'identifier'])
+				delete args[k];
 		}
 
 		return args;


### PR DESCRIPTION
Closes the dominant failure class in #24: ~90% of production `mcp_tool_call_error` events are the server rejecting **recoverable** LLM-generated arguments. The worker forwards tool args verbatim and re-fetches schemas every request, so the fix lives entirely server-side (Postel's law).

## Changes

**Reference parser** (`src/functions/reference-parser.ts` — notes/questions/word-links path)
- **Multi-digit chapters (Class A, the big one):** dropped `0-9` from the `BOOK_HEAD` trailing class so the greedy book-head no longer steals the first chapter digit (`"Mark 10:25"` was parsing book `"Mark 1"`, chapter `"0"`). This had been rejecting **every chapter ≥ 10** — most of the Bible — on TN/TQ.
- **Spaceless / invalid numbered codes:** numeric prefix now uses `\s*` so `"2KI"`/`"1Co"` parse like `"2 Kings"`/`"1 Corinthians"`; added `2KGS`/`1KGS` → `2KI`/`1KI`.

**MCP dispatch** (`ui/src/lib/mcp/UnifiedMCPHandler.ts`) — normalize args at the single chokepoint, before required-param validation. Each transform is additive and only fires when the canonical field is absent:
- **Class H:** `null` / array / non-object args → `{}`
- **Class D:** `language_code` / `languageCode` / `lang` → `language`
- **Class C:** decomposed `book` + `chapter` + `verse` → a single `reference` string
- **Class B:** `term` / `word` / `moduleId` / `topic` → bare `path` for path-required tools (the endpoints resolve a bare term across kt/names/other)

**Tool descriptions** (`src/mcp/tools-registry.ts`): document `path` provenance (`externalReference`) and the `term`/`word` aliases; note decomposed refs and long/multi-digit names are accepted. (Descriptions are the mode-proof coaching channel — modes can't clobber them.)

## Verification (Definition of Done)

Per #24, a repro suite (`scripts/issue24-dod-suite.mjs`) enumerates every logged failing pattern + regression controls and runs them as real `tools/call` requests.

- **Baseline vs prod:** 9/25 (the 16 Class A/B/C/D failures reproduce).
- **Parser probe** (`scripts/issue24-parser-probe.mts`): 19/19 local.
- **This PR's Cloudflare preview:** full suite must be **25/25 green before merge** — results will be posted here.

No version bump (repo uses manual `standard-version`); will bump at release if desired.

Refs #24