### PR TITLE
fix(mcp): structural decomposed-reference normalization (issue #24)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.4.2",
+  "version": "7.4.3",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/scripts/issue24-dod-suite.mjs
+++ b/scripts/issue24-dod-suite.mjs
@@ -83,7 +83,8 @@ const CASES = [
 	{ cls: 'C-key', name: 'word_links {book_id} 1JN 3:10', tool: 'fetch_translation_word_links', args: { book_id: '1JN', chapter: 3, verse: 10, language: 'en' }, kind: 'data', minItems: 1 },
 	{ cls: 'C-key', name: 'questions {bookId} Mark 10:23', tool: 'fetch_translation_questions', args: { bookId: 'Mark', chapter: 10, verse: 23, language: 'en' }, kind: 'data', minItems: 1 },
 	{ cls: 'C-key', name: 'notes chapter-only {book_id} 1TI 2', tool: 'fetch_translation_notes', args: { book_id: '1TI', chapter: 2, language: 'en' }, kind: 'data', minItems: 1 },
-	{ cls: 'C-key', name: 'scripture {book_id} JHN 3:16', tool: 'fetch_scripture', args: { book_id: 'JHN', chapter: 3, verse: 16, language: 'en' }, kind: 'ok', expectText: 'John' },
+	// expectText would match the VERSE CONTENT, not the book name — assert returned scripture data instead.
+	{ cls: 'C-key', name: 'scripture {book_id} JHN 3:16', tool: 'fetch_scripture', args: { book_id: 'JHN', chapter: 3, verse: 16, language: 'en' }, kind: 'data', minItems: 1 },
 
 	// ── Class D: language_code alias → language ──────────────────────────
 	{ cls: 'D', name: 'list_resources language_code=en', tool: 'list_resources_for_language', args: { language_code: 'en' }, kind: 'ok', expectText: 'en' },

--- a/scripts/issue24-dod-suite.mjs
+++ b/scripts/issue24-dod-suite.mjs
@@ -68,9 +68,22 @@ const CASES = [
 	{ cls: 'B', name: 'academy term=figs-metaphor (alias term→path)', tool: 'fetch_translation_academy', args: { term: 'figs-metaphor', language: 'en' }, kind: 'ok', expectText: 'etaphor' },
 
 	// ── Class C: decomposed book+chapter+verse → reference ────────────────
-	{ cls: 'C', name: 'notes decomposed 1CO 15:58', tool: 'fetch_translation_notes', args: { book: '1CO', chapter: 15, verse: 58, language: 'en' }, kind: 'data', minItems: 1 },
-	{ cls: 'C', name: 'word_links decomposed John 3:16', tool: 'fetch_translation_word_links', args: { book: 'John', chapter: 3, verse: 16, language: 'en' }, kind: 'data', minItems: 1 },
-	{ cls: 'C', name: 'questions decomposed Mark 10:23', tool: 'fetch_translation_questions', args: { book: 'Mark', chapter: 10, verse: 23, language: 'en' }, kind: 'data', minItems: 1 },
+	// The literal `book` key (what the first fix handled and the only shape the
+	// old suite tested — hence the false 36/36 confidence while prod stayed broken).
+	{ cls: 'C', name: 'notes decomposed {book} 1CO 15:58', tool: 'fetch_translation_notes', args: { book: '1CO', chapter: 15, verse: 58, language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'C', name: 'word_links decomposed {book} John 3:16', tool: 'fetch_translation_word_links', args: { book: 'John', chapter: 3, verse: 16, language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'C', name: 'questions decomposed {book} Mark 10:23', tool: 'fetch_translation_questions', args: { book: 'Mark', chapter: 10, verse: 23, language: 'en' }, kind: 'data', minItems: 1 },
+
+	// ── Class C (structural): the REAL prod key spellings (issue #24 root cause) ──
+	// These are the verbatim shapes from the 24h prod log that the book-only fix
+	// MISSED. The structural classifier must catch every "book*" key variant.
+	{ cls: 'C-key', name: 'notes {book_id} 2TH 3:13', tool: 'fetch_translation_notes', args: { book_id: '2TH', chapter: 3, verse: 13, language: 'en' }, kind: 'resolves' },
+	{ cls: 'C-key', name: 'notes {book_code} MAT 6:25', tool: 'fetch_translation_notes', args: { book_code: 'MAT', chapter: 6, verse: 25, language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'C-key', name: 'notes {bookId} MAT 6:5', tool: 'fetch_translation_notes', args: { bookId: 'MAT', language: 'en', chapter: 6, verse: 5 }, kind: 'data', minItems: 1 },
+	{ cls: 'C-key', name: 'word_links {book_id} 1JN 3:10', tool: 'fetch_translation_word_links', args: { book_id: '1JN', chapter: 3, verse: 10, language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'C-key', name: 'questions {bookId} Mark 10:23', tool: 'fetch_translation_questions', args: { bookId: 'Mark', chapter: 10, verse: 23, language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'C-key', name: 'notes chapter-only {book_id} 1TI 2', tool: 'fetch_translation_notes', args: { book_id: '1TI', chapter: 2, language: 'en' }, kind: 'data', minItems: 1 },
+	{ cls: 'C-key', name: 'scripture {book_id} JHN 3:16', tool: 'fetch_scripture', args: { book_id: 'JHN', chapter: 3, verse: 16, language: 'en' }, kind: 'ok', expectText: 'John' },
 
 	// ── Class D: language_code alias → language ──────────────────────────
 	{ cls: 'D', name: 'list_resources language_code=en', tool: 'list_resources_for_language', args: { language_code: 'en' }, kind: 'ok', expectText: 'en' },
@@ -103,7 +116,10 @@ const CASES = [
 	{ cls: 'PROD', name: '#8 notes {reference:"EZK 36:25-27"} (parse fixed; verse no-data)', tool: 'fetch_translation_notes', args: { reference: 'EZK 36:25-27' }, kind: 'resolves' },
 	{ cls: 'PROD', name: '#9 notes {reference:"Ruth 3:9",language:"pt"}', tool: 'fetch_translation_notes', args: { reference: 'Ruth 3:9', language: 'pt' }, kind: 'resolves' },
 	// Straggler found in staging A/B logs: model used `article` as the path synonym.
-	{ cls: 'PROD', name: 'academy {article:"translate-names"} (alias article→path)', tool: 'fetch_translation_academy', args: { article: 'translate-names' }, kind: 'ok', expectText: 'name' }
+	{ cls: 'PROD', name: 'academy {article:"translate-names"} (alias article→path)', tool: 'fetch_translation_academy', args: { article: 'translate-names' }, kind: 'ok', expectText: 'name' },
+	// Straggler from 24h prod log: model used `id` as the academy path synonym.
+	{ cls: 'PROD', name: 'academy {id:"figs-synecdoche"} (alias id→path)', tool: 'fetch_translation_academy', args: { id: 'figs-synecdoche' }, kind: 'resolves' },
+	{ cls: 'PROD', name: 'word {id:"grace"} (alias id→path)', tool: 'fetch_translation_word', args: { id: 'grace' }, kind: 'ok', expectText: 'grace' }
 ];
 
 async function callTool(tool, args) {

--- a/scripts/issue24-normalize-probe.mts
+++ b/scripts/issue24-normalize-probe.mts
@@ -1,0 +1,69 @@
+/**
+ * Issue #24 — local unit check for structural arg normalization.
+ *
+ * Drives the REAL UnifiedMCPHandler with a fake fetch that captures the
+ * outbound URL, so we can assert the normalized query WITHOUT a deployment.
+ * Covers the prod key spellings the book-only fix missed (book_id/bookId/
+ * book_code), range assembly, the `id` path alias, and the `version` collision
+ * guard (must NOT be eaten as a verse).
+ */
+import { UnifiedMCPHandler } from '../ui/src/lib/mcp/UnifiedMCPHandler.js';
+
+let lastUrl = '';
+const fakeFetch = (async (url: string) => {
+	lastUrl = String(url);
+	return new Response(JSON.stringify({ verseNotes: [], items: [], text: 'ok' }), {
+		status: 200,
+		headers: { 'content-type': 'application/json' },
+	});
+}) as unknown as typeof fetch;
+
+const handler = new UnifiedMCPHandler('https://example.test', fakeFetch);
+
+interface Probe {
+	name: string;
+	tool: string;
+	args: any;
+	/** decoded substrings that MUST appear in the outbound query */
+	want: string[];
+	/** decoded substrings that must NOT appear */
+	notWant?: string[];
+}
+
+const PROBES: Probe[] = [
+	{ name: '{book_id} 2TH 3:13', tool: 'fetch_translation_notes', args: { book_id: '2TH', chapter: 3, verse: 13, language: 'en' }, want: ['reference=2TH 3:13'], notWant: ['book_id'] },
+	{ name: '{bookId} MAT 6:5', tool: 'fetch_translation_notes', args: { bookId: 'MAT', chapter: 6, verse: 5, language: 'en' }, want: ['reference=MAT 6:5'], notWant: ['bookId'] },
+	{ name: '{book_code} MAT 6:25', tool: 'fetch_translation_notes', args: { book_code: 'MAT', chapter: 6, verse: 25, language: 'en' }, want: ['reference=MAT 6:25'], notWant: ['book_code'] },
+	{ name: '{book} 1CO 15:58 (still works)', tool: 'fetch_translation_notes', args: { book: '1CO', chapter: 15, verse: 58, language: 'en' }, want: ['reference=1CO 15:58'], notWant: ['book='] },
+	{ name: 'chapter-only {book_id} 1TI 2', tool: 'fetch_translation_notes', args: { book_id: '1TI', chapter: 2, language: 'en' }, want: ['reference=1TI 2'] },
+	{ name: 'range {book_id} GEN 1:1-3', tool: 'fetch_translation_notes', args: { book_id: 'GEN', chapter: 1, verse: 1, endVerse: 3, language: 'en' }, want: ['reference=GEN 1:1-3'] },
+	{ name: 'explicit reference wins; strays stripped', tool: 'fetch_translation_notes', args: { reference: 'John 3:16', book_id: 'XXX', chapter: 9, language: 'en' }, want: ['reference=John 3:16'], notWant: ['XXX', 'chapter'] },
+	{ name: 'version NOT eaten as verse', tool: 'fetch_scripture', args: { book: 'GEN', chapter: 1, verse: 1, version: 'ult', language: 'en' }, want: ['reference=GEN 1:1', 'version=ult'] },
+	{ name: 'academy {id} alias→path', tool: 'fetch_translation_academy', args: { id: 'figs-synecdoche', language: 'en' }, want: ['path=figs-synecdoche'], notWant: ['id='] },
+	{ name: 'word {id} alias→path', tool: 'fetch_translation_word', args: { id: 'grace', language: 'en' }, want: ['path=grace'] },
+];
+
+let fail = 0;
+for (const p of PROBES) {
+	lastUrl = '';
+	try {
+		await handler.handleToolCall(p.tool, p.args);
+	} catch (e) {
+		console.log(`FAIL  ${p.name} — threw: ${(e as Error).message}`);
+		fail++;
+		continue;
+	}
+	const decoded = decodeURIComponent(lastUrl).replace(/\+/g, ' ');
+	const missing = p.want.filter((w) => !decoded.includes(w));
+	const leaked = (p.notWant ?? []).filter((w) => decoded.includes(w));
+	const ok = missing.length === 0 && leaked.length === 0;
+	if (!ok) fail++;
+	console.log(`${ok ? 'PASS' : 'FAIL'}  ${p.name}`);
+	if (!ok) {
+		if (missing.length) console.log(`   MISSING: ${missing.join(' | ')}`);
+		if (leaked.length) console.log(`   LEAKED:  ${leaked.join(' | ')}`);
+		console.log(`   url: ${decoded}`);
+	}
+}
+console.log('\n' + (fail ? `${fail} FAILURES` : 'ALL NORMALIZE PROBES PASS'));
+process.exit(fail ? 1 : 0);

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -25,11 +25,12 @@ import { ListResourcesForLanguageArgs } from "../tools/listResourcesForLanguage.
  * Kept in one place so all fetch tools stay consistent in MCP/JSON-Schema.
  */
 const REFERENCE_INPUT_DESCRIPTION =
-  "Full Bible passage in one string: the book (USFM 3-letter code like JHN, or the book title in English or the request language, e.g. John, Juan, Génesis) plus chapter and verse or verse range, or a whole chapter. " +
-  "This is not only a book code — a bare code with no chapter/verse (e.g. only 'JHN') is wrong. " +
-  'Valid examples: "JHN 3:16", "John 3:16", "Juan 3:16" (use language: es), "GEN 1:1-3", "MAT 5" (entire chapter), "1 Corinthians 13:4-7". ' +
-  'Full English/localized book names and multi-digit chapters (e.g. "Mark 10:25") are accepted. ' +
-  "You may also send the parts separately as book + chapter + verse and they will be combined into one reference.";
+  "REQUIRED. Pass the whole passage as ONE string here — do NOT split it into separate book/chapter/verse fields. " +
+  "Format: book + chapter:verse (or verse range, or a whole chapter). The book may be a USFM 3-letter code (JHN), " +
+  "a full English title (John, Genesis), or the title in the request language (Juan, Génesis with language: es). " +
+  "A bare book code with no chapter/verse (e.g. only 'JHN') is NOT a valid reference. " +
+  'Valid examples: "John 3:16", "JHN 3:16", "Juan 3:16" (language: es), "GEN 1:1-3", "MAT 5" (entire chapter), "1 Corinthians 13:4-7". ' +
+  'Full/localized book names and multi-digit chapters (e.g. "Mark 10:25") are accepted.';
 
 /**
  * Tolerated-argument fields advertised on the input schemas (issue #24).
@@ -56,24 +57,33 @@ const LANGUAGE_ALIAS_FIELDS = {
   lang: z.string().optional().describe("Alias for `language`."),
 };
 
-/** Reference tools: decomposed book/chapter/verse + language aliases; `reference` becomes optional. */
+/**
+ * Reference tools: `reference` is the canonical (preferred) field. The
+ * decomposed book/chapter/verse fields are a FALLBACK kept only so strict
+ * schema-aware clients that already split a passage are still accepted — the
+ * server reassembles them into a single `reference` (issue #24). New callers
+ * should always send `reference`. `reference` is advertised optional only so
+ * the decomposed fallback can satisfy the requirement instead.
+ */
+const FALLBACK_DECOMPOSED_NOTE =
+  "Fallback only — prefer sending the whole passage in `reference`. If present, this is reassembled into a single `reference` server-side.";
 const REFERENCE_TOLERANCE_FIELDS = {
   reference: z.string().optional().describe(REFERENCE_INPUT_DESCRIPTION),
   book: z
     .string()
     .optional()
     .describe(
-      "Decomposed reference: book (USFM code or English/localized name). Combined with chapter/verse into a single `reference`. Prefer sending the whole `reference` string instead.",
+      `Book (USFM code or English/localized name). ${FALLBACK_DECOMPOSED_NOTE}`,
     ),
   chapter: intOrString()
     .optional()
-    .describe("Decomposed reference: chapter number."),
+    .describe(`Chapter number. ${FALLBACK_DECOMPOSED_NOTE}`),
   verse: intOrString()
     .optional()
-    .describe("Decomposed reference: verse number."),
+    .describe(`Verse number. ${FALLBACK_DECOMPOSED_NOTE}`),
   endVerse: intOrString()
     .optional()
-    .describe("Decomposed reference: end verse for a range."),
+    .describe(`End verse for a range. ${FALLBACK_DECOMPOSED_NOTE}`),
   ...LANGUAGE_ALIAS_FIELDS,
 };
 
@@ -91,6 +101,7 @@ const PATH_TOLERANCE_FIELDS = {
   moduleId: z.string().optional().describe("Alias for `path`."),
   module: z.string().optional().describe("Alias for `path`."),
   identifier: z.string().optional().describe("Alias for `path`."),
+  id: z.string().optional().describe("Alias for `path`."),
 };
 
 /**

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.4.2";
+export const VERSION = "7.4.3";
 
 export function getVersion(): string {
   return VERSION;

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tc-helps-ui",
 	"type": "module",
-	"version": "7.4.2",
+	"version": "7.4.3",
 	"scripts": {
 		"dev": "vite dev",
 		"build:js-sdk": "npm --prefix ../packages/js-sdk install --include=dev && npm --prefix ../packages/js-sdk run build",

--- a/ui/src/lib/mcp/UnifiedMCPHandler.ts
+++ b/ui/src/lib/mcp/UnifiedMCPHandler.ts
@@ -18,27 +18,85 @@ function firstNonBlank(...vals: unknown[]): unknown {
 	return undefined;
 }
 
-/**
- * Assemble a single `reference` string from decomposed book/chapter/verse args
- * (issue #24 Class C). The model sometimes sends {book,chapter,verse} instead of
- * one reference; the endpoints only accept a reference string.
- */
-function assembleReference(a: Record<string, any>): string {
-	const book = String(a.book).trim();
-	const chapter = firstNonBlank(a.chapter, a.startChapter, a.start_chapter);
-	const verse = firstNonBlank(a.verse, a.startVerse, a.start_verse);
-	const endVerse = firstNonBlank(a.endVerse, a.end_verse);
-	const endChapter = firstNonBlank(a.endChapter, a.end_chapter);
+/** Normalize an arg key for structural matching: drop _, -, spaces; lowercase. */
+function normKey(k: string): string {
+	return k.replace(/[_\s-]/g, '').toLowerCase();
+}
 
-	let ref = book;
-	if (!isBlank(chapter)) {
-		ref += ` ${String(chapter).trim()}`;
-		if (!isBlank(verse)) {
-			ref += `:${String(verse).trim()}`;
-			if (!isBlank(endVerse)) ref += `-${String(endVerse).trim()}`;
-		} else if (!isBlank(endChapter)) {
+type RefPart = 'book' | 'chapter' | 'verse' | 'endVerse' | 'endChapter';
+
+/**
+ * Classify an arg key as a decomposed-reference part by its STRUCTURE, not by
+ * matching a fixed list of names (issue #24 Class C).
+ *
+ * The first fix only matched the literal key `book` — but real production
+ * traffic spells the book a dozen ways (`book_id`, `bookId`, `book_code`, …),
+ * so it missed ~95% of decomposed calls. The fix is to match structurally:
+ *
+ *  - `book` is the high-variance dimension, so any key whose normalized form
+ *    STARTS WITH `book` (book, bookId, book_code, bookName, bookUsfm, …) is the
+ *    book. This is robust to permutations we have not seen yet.
+ *  - chapter/verse have no observed variance, so they use prefix matches that
+ *    cannot collide with unrelated params: `startsWith('verse')` does NOT match
+ *    `version` (`'version'.startsWith('verse')` is false). The range start/end
+ *    bounds are checked first so they are not swallowed by the plain cases.
+ *
+ * Returns the canonical part name, or null if the key is not a reference part.
+ */
+function classifyRefPart(nk: string): RefPart | null {
+	if (nk.startsWith('book')) return 'book';
+	if (nk.startsWith('endverse') || nk === 'verseend') return 'endVerse';
+	if (nk.startsWith('endchapter') || nk === 'chapterend') return 'endChapter';
+	// Range start bounds collapse onto the primary chapter/verse.
+	if (nk.startsWith('startchapter') || nk.startsWith('fromchapter')) return 'chapter';
+	if (nk.startsWith('startverse') || nk.startsWith('fromverse')) return 'verse';
+	if (nk.startsWith('chapter') || nk === 'chap') return 'chapter';
+	if (nk.startsWith('verse') || nk === 'v') return 'verse';
+	return null;
+}
+
+interface DecomposedRef {
+	parts: Partial<Record<RefPart, unknown>>;
+	/** Every original arg key that was classified as a reference part. */
+	consumedKeys: string[];
+}
+
+/**
+ * Structurally collect decomposed reference parts from arbitrary arg keys
+ * (issue #24 Class C). Scans every key once; first non-blank value wins per
+ * part. `reference` itself is never treated as a part.
+ */
+function collectDecomposedRef(args: Record<string, any>): DecomposedRef {
+	const parts: Partial<Record<RefPart, unknown>> = {};
+	const consumedKeys: string[] = [];
+	for (const k of Object.keys(args)) {
+		if (k === 'reference') continue;
+		const part = classifyRefPart(normKey(k));
+		if (!part) continue;
+		consumedKeys.push(k);
+		if (parts[part] === undefined && !isBlank(args[k])) {
+			parts[part] = args[k];
+		}
+	}
+	return { parts, consumedKeys };
+}
+
+/**
+ * Assemble a single `reference` string from collected decomposed parts
+ * (issue #24 Class C). The model sometimes sends the passage split across
+ * book/chapter/verse keys instead of one reference; the endpoints only accept
+ * a reference string.
+ */
+function assembleReference(parts: Partial<Record<RefPart, unknown>>): string {
+	let ref = String(parts.book).trim();
+	if (!isBlank(parts.chapter)) {
+		ref += ` ${String(parts.chapter).trim()}`;
+		if (!isBlank(parts.verse)) {
+			ref += `:${String(parts.verse).trim()}`;
+			if (!isBlank(parts.endVerse)) ref += `-${String(parts.endVerse).trim()}`;
+		} else if (!isBlank(parts.endChapter)) {
 			// Whole-chapter range, e.g. {book:"Titus",chapter:1,endChapter:2} → "Titus 1-2"
-			ref += `-${String(endChapter).trim()}`;
+			ref += `-${String(parts.endChapter).trim()}`;
 		}
 	}
 	return ref;
@@ -91,8 +149,11 @@ export class UnifiedMCPHandler {
 	 *
 	 * - Class H: args arriving as null / an array / a non-object → {}
 	 * - Class D: language_code / languageCode / lang → language
-	 * - Class C: decomposed book + chapter + verse → a single `reference`
-	 * - Class B: term / word / moduleId / topic → `path` (for path-required tools)
+	 * - Class C: decomposed reference parts → a single `reference`. Matched
+	 *            STRUCTURALLY (any `book*` key, e.g. book_id/bookId/book_code),
+	 *            not against a fixed name list — see classifyRefPart().
+	 * - Class B: term / word / name / article / moduleId / id / topic → `path`
+	 *            (for path-required tools)
 	 */
 	private normalizeArgs(
 		toolName: string,
@@ -116,29 +177,21 @@ export class UnifiedMCPHandler {
 		delete args.lang;
 
 		// Class C — decomposed book/chapter/verse → reference (only for ref tools).
-		if (requiredParams.includes('reference') && isBlank(args.reference) && !isBlank(args.book)) {
-			args.reference = assembleReference(args);
-			console.log(
-				`[UNIFIED HANDLER] Assembled reference for ${toolName} from decomposed args:`,
-				args.reference
-			);
-		}
-		if (!isBlank(args.reference)) {
-			// Strip decomposed leftovers so they don't leak into the query string.
-			for (const k of [
-				'book',
-				'chapter',
-				'verse',
-				'startChapter',
-				'start_chapter',
-				'startVerse',
-				'start_verse',
-				'endVerse',
-				'end_verse',
-				'endChapter',
-				'end_chapter'
-			]) {
-				delete args[k];
+		// Structural: catches book/book_id/bookId/book_code/… (any "book*" key),
+		// not just the literal `book` the first fix matched (issue #24 root cause).
+		if (requiredParams.includes('reference')) {
+			const { parts, consumedKeys } = collectDecomposedRef(args);
+			if (isBlank(args.reference) && !isBlank(parts.book)) {
+				args.reference = assembleReference(parts);
+				console.log(
+					`[UNIFIED HANDLER] Assembled reference for ${toolName} from decomposed args:`,
+					args.reference
+				);
+			}
+			// Once a reference exists (assembled or supplied), strip the decomposed
+			// leftovers so they don't leak into the query string.
+			if (!isBlank(args.reference)) {
+				for (const k of consumedKeys) delete args[k];
 			}
 		}
 
@@ -148,7 +201,7 @@ export class UnifiedMCPHandler {
 		if (requiredParams.includes('path')) {
 			if (isBlank(args.path)) {
 				// Synonyms observed in prod/staging logs the model sends instead of
-				// `path`: term / word / name / article / moduleId / identifier
+				// `path`: term / word / name / article / moduleId / identifier / id
 				// (issue #24). `topic` is last — it's a legitimate filter on these
 				// tools, so only fall back to it when nothing clearer is present.
 				for (const k of [
@@ -159,6 +212,7 @@ export class UnifiedMCPHandler {
 					'moduleId',
 					'module',
 					'identifier',
+					'id',
 					'topic'
 				]) {
 					if (!isBlank(args[k])) {
@@ -171,7 +225,7 @@ export class UnifiedMCPHandler {
 			}
 			// `term` is a deprecated endpoint param (rejected downstream); the other
 			// synonyms aren't endpoint params either — drop any we didn't consume.
-			for (const k of ['term', 'word', 'name', 'article', 'moduleId', 'module', 'identifier'])
+			for (const k of ['term', 'word', 'name', 'article', 'moduleId', 'module', 'identifier', 'id'])
 				delete args[k];
 		}
 

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.4.2';
+export const VERSION = '7.4.3';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.4.2';
+const BUILD_VERSION = '7.4.3';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {


### PR DESCRIPTION
## Why

PR #25 normalized decomposed references but only matched the literal key `book`. Production traffic spells the book a dozen ways — `book_id` (12 of 21 decomposed calls in the 24h log), `bookId`, `book_code` — so **Class C stayed broken** (prod: 11 errors before #25, still 10 after). The DoD suite tested only `book`, which is why it passed 36/36 while real traffic kept failing. Root-cause writeup on issue #24.

## What

**Structural, not enumerated.** `UnifiedMCPHandler.normalizeArgs` now classifies each arg key by its normalized form (strip `_`/`-`/space, lowercase):
- any key starting with `book` → the book (`book`, `book_id`, `bookId`, `book_code`, `bookName`, `bookUsfm`, … + future spellings)
- `chapter`/`verse` use prefix matches that **cannot** collide with `version` (`'version'.startsWith('verse')` is false)
- range start/end bounds (`startChapter`, `endVerse`, …) handled first

One rule catches every current and future "book" spelling. Plus:
- **`id` path synonym** added (academy/word) — the last Class B straggler from the 24h log (`{id:"figs-synecdoche"}`).
- **Descriptions re-pointed** to push a single `reference` string, and the decomposed `book/chapter/verse` fields demoted to an explicit "fallback only" so the schema the model reads no longer *invites* decomposition.
- **DoD suite** extended with the verbatim prod arg shapes (`book_id`/`bookId`/`book_code`, chapter-only, ranges, `{id:...}`) the book-only suite never exercised — closing the false-confidence gap.
- **New `scripts/issue24-normalize-probe.mts`** — a deployment-free unit check driving the real handler with a fake fetch; asserts the assembled query per key spelling + the `version`-collision guard.

## Verification (preview `cbc39115`, commit 61c97bf)
- **DoD suite: 45/45** — including every prod key spelling: `{book_id}`, `{book_code}`, `{bookId}`, chapter-only `{book_id}`, `{id}` path alias.
- **Heavy smoke: 113/113** (A 66, B 22, C 9, CTRL 10, D 3, H 3) — no regressions.
- **Local normalize probe: 10/10**, schema probe: PASS.

Endpoint validation is untouched; every transform is additive and fires only when the canonical field is absent, so well-formed calls pass through unchanged.

## Companion change (worker side)
The org-level `tool_guidance` prompt override in bt-servant-worker (`unfoldingWord`) contained "For book parameter, always use three-letter codes," which actively taught the model to decompose. That line has been removed on both staging and prod (per-tool arg format belongs in the tool schema, which this PR fixes — not the consumer's shared prompt). Together: the model is steered toward one `reference` string AND the server tolerates the decomposed shapes if it still splits.