### PR TITLE
fix(mcp): structurally tolerate _id-suffixed path synonyms (#28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.4.3",
+  "version": "7.4.4",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -22,7 +22,7 @@
     },
     "../../ui": {
       "name": "tc-helps-ui",
-      "version": "7.4.1",
+      "version": "7.4.4",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.1",
         "@neoconfetti/svelte": "^2.0.0",

--- a/scripts/issue24-dod-suite.mjs
+++ b/scripts/issue24-dod-suite.mjs
@@ -86,6 +86,16 @@ const CASES = [
 	// expectText would match the VERSE CONTENT, not the book name — assert returned scripture data instead.
 	{ cls: 'C-key', name: 'scripture {book_id} JHN 3:16', tool: 'fetch_scripture', args: { book_id: 'JHN', chapter: 3, verse: 16, language: 'en' }, kind: 'data', minItems: 1 },
 
+	// ── Class B (structural): `_id`-suffixed path synonyms (issue #28) ───
+	// Verbatim shapes from the 24h post-#27 prod log that the fixed-list path
+	// match MISSED. classifyPathSynonym must resolve every `<synonym>_id`/Id form.
+	{ cls: 'B-id', name: 'word {word_id:"love"} (alias word_id→path)', tool: 'fetch_translation_word', args: { word_id: 'love', language: 'en' }, kind: 'ok', expectText: 'love' },
+	{ cls: 'B-id', name: 'word {wordId:"grace"} (camelCase)', tool: 'fetch_translation_word', args: { wordId: 'grace', language: 'en' }, kind: 'ok', expectText: 'grace' },
+	{ cls: 'B-id', name: 'academy {article_id:"figs-activepassive"}', tool: 'fetch_translation_academy', args: { article_id: 'figs-activepassive', language: 'en' }, kind: 'resolves' },
+	{ cls: 'B-id', name: 'academy {articleId:"figs-metaphor"} (camelCase)', tool: 'fetch_translation_academy', args: { articleId: 'figs-metaphor', language: 'en' }, kind: 'ok', expectText: 'etaphor' },
+	{ cls: 'B-id', name: 'word {term_id:"faith"} (generalization)', tool: 'fetch_translation_word', args: { term_id: 'faith', language: 'en' }, kind: 'resolves' },
+	{ cls: 'B-id', name: 'word {uuid,word:"love"} (uuid NOT consumed as path)', tool: 'fetch_translation_word', args: { uuid: 'x', word: 'love', language: 'en' }, kind: 'ok', expectText: 'love' },
+
 	// ── Class D: language_code alias → language ──────────────────────────
 	{ cls: 'D', name: 'list_resources language_code=en', tool: 'list_resources_for_language', args: { language_code: 'en' }, kind: 'ok', expectText: 'en' },
 

--- a/scripts/issue24-normalize-probe.mts
+++ b/scripts/issue24-normalize-probe.mts
@@ -41,6 +41,14 @@ const PROBES: Probe[] = [
 	{ name: 'version NOT eaten as verse', tool: 'fetch_scripture', args: { book: 'GEN', chapter: 1, verse: 1, version: 'ult', language: 'en' }, want: ['reference=GEN 1:1', 'version=ult'] },
 	{ name: 'academy {id} alias→path', tool: 'fetch_translation_academy', args: { id: 'figs-synecdoche', language: 'en' }, want: ['path=figs-synecdoche'], notWant: ['id='] },
 	{ name: 'word {id} alias→path', tool: 'fetch_translation_word', args: { id: 'grace', language: 'en' }, want: ['path=grace'] },
+	// issue #28 — structural `_id`-suffixed path synonyms (verbatim prod shapes).
+	{ name: 'word {word_id} alias→path', tool: 'fetch_translation_word', args: { word_id: 'love', language: 'en' }, want: ['path=love'], notWant: ['word_id', 'word='] },
+	{ name: 'word {wordId} alias→path', tool: 'fetch_translation_word', args: { wordId: 'grace', language: 'en' }, want: ['path=grace'], notWant: ['wordId'] },
+	{ name: 'academy {article_id} alias→path', tool: 'fetch_translation_academy', args: { article_id: 'figs-activepassive', language: 'en' }, want: ['path=figs-activepassive'], notWant: ['article_id'] },
+	{ name: 'academy {articleId} alias→path', tool: 'fetch_translation_academy', args: { articleId: 'figs-metaphor', language: 'en' }, want: ['path=figs-metaphor'], notWant: ['articleId'] },
+	{ name: 'word {term_id} alias→path (generalization)', tool: 'fetch_translation_word', args: { term_id: 'faith', language: 'en' }, want: ['path=faith'], notWant: ['term_id'] },
+	{ name: 'word {uuid} NOT eaten as path; word wins', tool: 'fetch_translation_word', args: { uuid: 'x', word: 'love', language: 'en' }, want: ['path=love'], notWant: ['path=x'] },
+	{ name: 'word {path} canonical unchanged (control)', tool: 'fetch_translation_word', args: { path: 'bible/kt/love', language: 'en' }, want: ['path=bible/kt/love'] },
 ];
 
 let fail = 0;

--- a/src/mcp/tools-registry.ts
+++ b/src/mcp/tools-registry.ts
@@ -167,6 +167,7 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
         "Fetch the dictionary article for a biblical term (e.g. grace, love, Abraham, covenant). " +
         'Identify the term with `path` — preferably the value from `externalReference` in a fetch_translation_word_links response (e.g. "bible/kt/love") — ' +
         'but a plain term name also works: send `path: "love"`, or `term`/`word: "love"` and it is resolved across all categories (kt/names/other). ' +
+        "`<synonym>_id`/`<synonym>Id` forms (e.g. `word_id`, `wordId`) are also accepted, but `path` is preferred. " +
         "No file extensions.",
       inputSchema: GetTranslationWordArgs.extend({
         ...PATH_TOLERANCE_FIELDS,
@@ -179,6 +180,7 @@ export function getMCPToolDefinitions(): MCPToolDefinition[] {
         "Fetch Translation Academy training articles teaching translation principles, methods, and techniques. " +
         'Identify the article with `path` — preferably the value from `externalReference` in a fetch_translation_notes response (e.g. "translate/figs-metaphor") — ' +
         'but a plain module id also works: send `path: "figs-metaphor"`, or `term`/`moduleId: "figs-metaphor"` and it is resolved across categories. ' +
+        "`<synonym>_id`/`<synonym>Id` forms (e.g. `article_id`, `articleId`) are also accepted, but `path` is preferred. " +
         "No file extensions.",
       inputSchema: FetchTranslationAcademyArgs.extend({
         ...PATH_TOLERANCE_FIELDS,

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.4.3";
+export const VERSION = "7.4.4";
 
 export function getVersion(): string {
   return VERSION;

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tc-helps-ui",
-	"version": "7.4.1",
+	"version": "7.4.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tc-helps-ui",
-			"version": "7.4.1",
+			"version": "7.4.4",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",
@@ -108,7 +108,6 @@
 			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
 			"integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
 			"license": "MIT OR Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"mime": "^3.0.0"
 			},
@@ -121,7 +120,6 @@
 			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
 			"integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
 			"license": "MIT OR Apache-2.0",
-			"peer": true,
 			"peerDependencies": {
 				"unenv": "2.0.0-rc.14",
 				"workerd": "^1.20250124.0"
@@ -144,7 +142,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=16"
 			}
@@ -161,7 +158,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=16"
 			}
@@ -178,7 +174,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=16"
 			}
@@ -195,7 +190,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=16"
 			}
@@ -212,7 +206,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=16"
 			}
@@ -221,14 +214,14 @@
 			"version": "4.20260203.0",
 			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260203.0.tgz",
 			"integrity": "sha512-XD2uglpGbVppjXXLuAdalKkcTi/i4TyQSx0w/ijJbvrR1Cfm7zNkxtvFBNy3tBNxZOiFIJtw5bszifQB1eow6A==",
-			"license": "MIT OR Apache-2.0"
+			"license": "MIT OR Apache-2.0",
+			"peer": true
 		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "0.3.9"
 			},
@@ -241,7 +234,6 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -262,7 +254,6 @@
 			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
 			"integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
 			"license": "ISC",
-			"peer": true,
 			"peerDependencies": {
 				"esbuild": "*"
 			}
@@ -272,7 +263,6 @@
 			"resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
 			"integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
 			"license": "ISC",
-			"peer": true,
 			"dependencies": {
 				"escape-string-regexp": "^4.0.0",
 				"rollup-plugin-node-polyfills": "^0.2.1"
@@ -904,7 +894,6 @@
 			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
 			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -995,7 +984,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
@@ -1018,7 +1006,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
@@ -1041,7 +1028,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
@@ -1058,7 +1044,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
@@ -1075,7 +1060,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
@@ -1092,7 +1076,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
@@ -1109,7 +1092,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
@@ -1126,7 +1108,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
@@ -1143,7 +1124,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
@@ -1160,7 +1140,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
@@ -1177,7 +1156,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
@@ -1200,7 +1178,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
@@ -1223,7 +1200,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
@@ -1246,7 +1222,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
@@ -1269,7 +1244,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
@@ -1292,7 +1266,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
@@ -1312,7 +1285,6 @@
 			],
 			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"@emnapi/runtime": "^1.2.0"
 			},
@@ -1335,7 +1307,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
@@ -1355,7 +1326,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
 			},
@@ -1848,6 +1818,7 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.50.2.tgz",
 			"integrity": "sha512-875hTUkEbz+MyJIxWbQjfMaekqdmEKUUfR7JyKcpfMRZqcGyrO9Gd+iS1D/Dx8LpE5FEtutWGOtlAh4ReSAiOA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@sveltejs/acorn-typescript": "^1.0.5",
@@ -1890,6 +1861,7 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-6.2.4.tgz",
 			"integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^5.0.0",
 				"deepmerge": "^4.3.1",
@@ -2198,6 +2170,7 @@
 			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
@@ -2288,6 +2261,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.10.tgz",
 			"integrity": "sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -2349,6 +2323,7 @@
 			"integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.54.0",
 				"@typescript-eslint/types": "8.54.0",
@@ -2566,6 +2541,7 @@
 			"integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@testing-library/dom": "^10.4.0",
 				"@testing-library/user-event": "^14.6.1",
@@ -2729,6 +2705,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2751,7 +2728,6 @@
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
 			"integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -2837,7 +2813,6 @@
 			"resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
 			"integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"printable-characters": "^1.0.42"
 			}
@@ -2872,8 +2847,7 @@
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
 			"integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/body-parser": {
 			"version": "2.2.2",
@@ -3043,7 +3017,6 @@
 			"integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"color-convert": "^2.0.1",
 				"color-string": "^1.9.0"
@@ -3078,7 +3051,6 @@
 			"integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"color-name": "^1.0.0",
 				"simple-swizzle": "^0.2.2"
@@ -3179,8 +3151,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
 			"integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -3229,8 +3200,7 @@
 			"version": "6.1.4",
 			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
 			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/depd": {
 			"version": "2.0.0",
@@ -3358,6 +3328,7 @@
 			"integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -3416,6 +3387,7 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -3698,7 +3670,6 @@
 			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
 			"integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6"
 			},
@@ -3787,8 +3758,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
 			"integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -4004,7 +3974,6 @@
 			"resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
 			"integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
 			"license": "Unlicense",
-			"peer": true,
 			"dependencies": {
 				"data-uri-to-buffer": "^2.0.0",
 				"source-map": "^0.6.1"
@@ -4027,8 +3996,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-			"license": "BSD-2-Clause",
-			"peer": true
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/globals": {
 			"version": "16.5.0",
@@ -4198,8 +4166,7 @@
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
 			"integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
@@ -4736,7 +4703,6 @@
 			"resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
 			"integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"mime": "cli.js"
 			},
@@ -4774,7 +4740,6 @@
 			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
 			"integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"acorn": "8.14.0",
@@ -4800,7 +4765,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
 			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -4813,7 +4777,6 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
 			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10.0.0"
 			},
@@ -4835,7 +4798,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
 			"integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -4882,7 +4844,6 @@
 			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
 			"integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"mustache": "bin/mustache"
 			}
@@ -4956,8 +4917,7 @@
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
 			"integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/on-finished": {
 			"version": "2.4.1",
@@ -5108,6 +5068,7 @@
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -5175,6 +5136,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -5308,6 +5270,7 @@
 			"integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -5324,6 +5287,7 @@
 			"integrity": "sha512-xL49LCloMoZRvSwa6IEdN2GV6cq2IqpYGstYtMT+5wmml1/dClEoI0MZR78MiVPpu6BdQFfN0/y73yO6+br5Pg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"prettier": "^3.0.0",
 				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
@@ -5448,8 +5412,7 @@
 			"version": "1.0.42",
 			"resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
 			"integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
-			"license": "Unlicense",
-			"peer": true
+			"license": "Unlicense"
 		},
 		"node_modules/prism-svelte": {
 			"version": "0.4.7",
@@ -5627,7 +5590,6 @@
 			"integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
 			"deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"estree-walker": "^0.6.1",
 				"magic-string": "^0.25.3",
@@ -5638,15 +5600,13 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
 			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/rollup-plugin-inject/node_modules/magic-string": {
 			"version": "0.25.9",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
 			"integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"sourcemap-codec": "^1.4.8"
 			}
@@ -5656,7 +5616,6 @@
 			"resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
 			"integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"rollup-plugin-inject": "^3.0.0"
 			}
@@ -5666,7 +5625,6 @@
 			"resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
 			"integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"estree-walker": "^0.6.1"
 			}
@@ -5675,8 +5633,7 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
 			"integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/router": {
 			"version": "2.2.0",
@@ -5789,7 +5746,6 @@
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"color": "^4.2.3",
 				"detect-libc": "^2.0.3",
@@ -5929,7 +5885,6 @@
 			"integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"is-arrayish": "^0.3.1"
 			}
@@ -5953,7 +5908,6 @@
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -5972,8 +5926,7 @@
 			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
 			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
 			"deprecated": "Please use @jridgewell/sourcemap-codec instead",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/stackback": {
 			"version": "0.0.2",
@@ -5987,7 +5940,6 @@
 			"resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
 			"integrity": "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==",
 			"license": "Unlicense",
-			"peer": true,
 			"dependencies": {
 				"as-table": "^1.0.36",
 				"get-source": "^2.0.12"
@@ -6014,7 +5966,6 @@
 			"resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
 			"integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=4",
 				"npm": ">=6"
@@ -6071,6 +6022,7 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.49.1.tgz",
 			"integrity": "sha512-jj95WnbKbXsXXngYj28a4zx8jeZx50CN/J4r0CEeax2pbfdsETv/J1K8V9Hbu3DCXnpHz5qAikICuxEooi7eNQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -6173,7 +6125,8 @@
 			"version": "4.1.18",
 			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
 			"integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/tapable": {
 			"version": "2.3.0",
@@ -6319,6 +6272,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"devOptional": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -6355,15 +6309,13 @@
 			"version": "1.6.3",
 			"resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
 			"integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/undici": {
 			"version": "5.29.0",
 			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
 			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@fastify/busboy": "^2.0.0"
 			},
@@ -6511,6 +6463,7 @@
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
 			"integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -7096,6 +7049,7 @@
 			"integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/chai": "^5.2.2",
 				"@vitest/expect": "3.2.4",
@@ -7262,7 +7216,6 @@
 			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
 			"integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
 			"license": "MIT OR Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.3.4",
 				"@cloudflare/unenv-preset": "2.0.2",
@@ -7307,7 +7260,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7324,7 +7276,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7341,7 +7292,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7358,7 +7308,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7375,7 +7324,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7392,7 +7340,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7409,7 +7356,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7426,7 +7372,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7443,7 +7388,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7460,7 +7404,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7477,7 +7420,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7494,7 +7436,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7511,7 +7452,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7528,7 +7468,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7545,7 +7484,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7562,7 +7500,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7579,7 +7516,6 @@
 			"os": [
 				"netbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7596,7 +7532,6 @@
 			"os": [
 				"openbsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7613,7 +7548,6 @@
 			"os": [
 				"sunos"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7630,7 +7564,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7647,7 +7580,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7664,7 +7596,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -7675,7 +7606,6 @@
 			"integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -7711,8 +7641,7 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
 			"integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
@@ -7742,23 +7671,6 @@
 				}
 			}
 		},
-		"node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -7777,7 +7689,6 @@
 			"resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
 			"integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cookie": "^0.7.1",
 				"mustache": "^4.2.0",
@@ -7789,7 +7700,6 @@
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
 			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -7805,6 +7715,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
 			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tc-helps-ui",
 	"type": "module",
-	"version": "7.4.3",
+	"version": "7.4.4",
 	"scripts": {
 		"dev": "vite dev",
 		"build:js-sdk": "npm --prefix ../packages/js-sdk install --include=dev && npm --prefix ../packages/js-sdk run build",

--- a/ui/src/lib/mcp/UnifiedMCPHandler.ts
+++ b/ui/src/lib/mcp/UnifiedMCPHandler.ts
@@ -55,6 +55,36 @@ function classifyRefPart(nk: string): RefPart | null {
 	return null;
 }
 
+/** Canonical bare-`path` synonyms (issue #24 Class B). `topic` is excluded — it
+ *  is a legitimate filter on these tools, handled only as a last-resort fallback. */
+const PATH_SYNONYMS = new Set([
+	'term',
+	'word',
+	'name',
+	'article',
+	'module',
+	'moduleid',
+	'identifier'
+]);
+
+/**
+ * Classify an arg key as a `path` synonym STRUCTURALLY (issue #24 Round 3 / #28),
+ * returning its canonical base or null. Catches `<synonym>_id` / `<synonym>Id`
+ * (word_id, wordId, article_id, …) the model emits without enumerating every
+ * spelling — same principle as classifyRefPart() for `book*`. `nk` is normKey(key).
+ *
+ * The trailing `id` is only stripped when the remainder is a known synonym, so it
+ * cannot misfire: `uuid` → `uu` ∉ set → ignored; `identifier` is matched whole.
+ */
+function classifyPathSynonym(nk: string): string | null {
+	if (nk === 'id') return 'id'; // bare id
+	if (PATH_SYNONYMS.has(nk)) return nk; // term/word/name/article/module/moduleid/identifier
+	if (nk.endsWith('id') && PATH_SYNONYMS.has(nk.slice(0, -2))) {
+		return nk.slice(0, -2); // word_id->word, article_id->article, term_id->term
+	}
+	return null;
+}
+
 interface DecomposedRef {
 	parts: Partial<Record<RefPart, unknown>>;
 	/** Every original arg key that was classified as a reference part. */
@@ -153,7 +183,9 @@ export class UnifiedMCPHandler {
 	 *            STRUCTURALLY (any `book*` key, e.g. book_id/bookId/book_code),
 	 *            not against a fixed name list — see classifyRefPart().
 	 * - Class B: term / word / name / article / moduleId / id / topic → `path`
-	 *            (for path-required tools)
+	 *            (for path-required tools). Matched STRUCTURALLY, so `<synonym>_id`
+	 *            / `<synonym>Id` (word_id, article_id, …) resolve too — see
+	 *            classifyPathSynonym().
 	 */
 	private normalizeArgs(
 		toolName: string,
@@ -197,36 +229,49 @@ export class UnifiedMCPHandler {
 
 		// Class B — term/word synonyms → bare `path` (path-required tools only).
 		// The endpoints resolve a bare term across all categories, so the synonym
-		// value is passed through verbatim as the path.
+		// value is passed through verbatim as the path. Synonyms are matched
+		// STRUCTURALLY (classifyPathSynonym), so `<synonym>_id`/`<synonym>Id`
+		// spellings the model emits (word_id, article_id, …) resolve too — issue #28.
 		if (requiredParams.includes('path')) {
 			if (isBlank(args.path)) {
-				// Synonyms observed in prod/staging logs the model sends instead of
-				// `path`: term / word / name / article / moduleId / identifier / id
-				// (issue #24). `topic` is last — it's a legitimate filter on these
-				// tools, so only fall back to it when nothing clearer is present.
-				for (const k of [
+				// Map each canonical synonym to the model's original arg key (first
+				// non-blank wins). Then pick by priority — the model's preferred
+				// identifier wins. `topic` is NOT a synonym: it's a real filter, used
+				// as the path only as a last resort when nothing clearer is present.
+				const bySyn = new Map<string, string>();
+				for (const k of Object.keys(args)) {
+					const syn = classifyPathSynonym(normKey(k));
+					if (syn && !isBlank(args[k]) && !bySyn.has(syn)) bySyn.set(syn, k);
+				}
+				const PRIORITY = [
 					'term',
 					'word',
 					'name',
 					'article',
-					'moduleId',
 					'module',
+					'moduleid',
 					'identifier',
-					'id',
-					'topic'
-				]) {
-					if (!isBlank(args[k])) {
+					'id'
+				];
+				for (const syn of PRIORITY) {
+					const k = bySyn.get(syn);
+					if (k) {
 						args.path = String(args[k]).trim();
-						if (k === 'topic') delete args.topic; // consumed the filter as the path
 						console.log(`[UNIFIED HANDLER] Aliased path for ${toolName} from ${k}:`, args.path);
 						break;
 					}
 				}
+				if (isBlank(args.path) && !isBlank(args.topic)) {
+					args.path = String(args.topic).trim();
+					delete args.topic; // consumed the filter as the path
+					console.log(`[UNIFIED HANDLER] Aliased path for ${toolName} from topic:`, args.path);
+				}
 			}
-			// `term` is a deprecated endpoint param (rejected downstream); the other
-			// synonyms aren't endpoint params either — drop any we didn't consume.
-			for (const k of ['term', 'word', 'name', 'article', 'moduleId', 'module', 'identifier', 'id'])
-				delete args[k];
+			// These synonyms aren't endpoint params (`term` is a rejected deprecated
+			// one); strip any consumed key so it doesn't leak into the query string.
+			for (const k of Object.keys(args)) {
+				if (k !== 'path' && classifyPathSynonym(normKey(k)) !== null) delete args[k];
+			}
 		}
 
 		return args;

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.4.3';
+export const VERSION = '7.4.4';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.4.3';
+const BUILD_VERSION = '7.4.4';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {


### PR DESCRIPTION
## Summary

- The two `path`-required MCP tools (`fetch_translation_word`, `fetch_translation_academy`) rejected LLM calls whose identifier arrived under an `_id`-suffixed synonym key (`word_id`, `article_id`, `wordId`, `articleId`, …) with `Missing required parameter: path` — a live prod error (~6/day, sustained through the 24h post-#27 monitor).
- Root cause was the same class of brittleness #27 fixed on the book side: the path-synonym matcher in `normalizeArgs()` was a **fixed enumerated list** that didn't cover the open-ended `_id` suffix space the model generalizes to.
- Fix mirrors #27: a structural `classifyPathSynonym()` (analog of `classifyRefPart()`) matches each normalized arg key against the canonical synonym set **and** its `<synonym>+id` form, instead of enumerating spellings. The trailing `id` is only stripped when the remainder is a known synonym, so unrelated keys (`uuid`, legit params) are never consumed as the path.
- Tool descriptions advertise the `<synonym>_id`/`Id` tolerance; `.passthrough()` already permits the keys (no brittle per-variant schema fields added).
- Patch version bump `7.4.3 → 7.4.4`.

## Test plan

- ✅ `npx tsx scripts/issue24-normalize-probe.mts` → **ALL 18 NORMALIZE PROBES PASS** (deployment-free gate: drives the real handler, asserts every `_id` shape resolves to the right `path`, camelCase works, `term_id` generalizes, and `uuid` is NOT eaten as the path).
- ✅ Edited files typecheck clean (pre-existing TS errors elsewhere in `src/config/*` are unrelated).
- Added verbatim prod shapes to `scripts/issue24-dod-suite.mjs` (live JSON-RPC) and `scripts/issue24-normalize-probe.mts`.
- ⏳ Remaining (per acceptance criteria, needs deploy): run `node scripts/issue24-dod-suite.mjs <preview-url>` against the preview, then confirm prod `mcp_tool_call_error` Class-B `_id` count → 0 after deploy.
- ⚠️ Note: the `test-build` CI job has a known stale smoke-test failure on every PR (tracked in #26), unrelated to this change.

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)