### PR TITLE
fix(mcp): report unpublished resources as 'not available', not server down (#30)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,8 @@ jobs:
           cd ui && npx wrangler pages dev .svelte-kit/cloudflare --port 8788 &
           sleep 8
           curl -f http://localhost:8788/about | grep -q "About"
-          curl -f http://localhost:8788/api | grep -q "Translation Helps"
+          # Use a real API route — bare /api has no index route and 404s (issue #26)
+          curl -f http://localhost:8788/api/health | grep -q "healthy"
           status=$(curl -s -o /dev/null -w "%{http_code}" -X GET \
             -H "Accept: text/event-stream" http://localhost:8788/api/mcp)
           [ "$status" = "405" ] || (echo "GET /api/mcp expected 405, got $status" && exit 1)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "translation-helps-mcp",
-  "version": "7.4.4",
+  "version": "7.4.5",
   "description": "MCP Server for aggregating Bible translation resources from Door43",
   "type": "module",
   "scripts": {

--- a/packages/js-sdk/package-lock.json
+++ b/packages/js-sdk/package-lock.json
@@ -22,7 +22,7 @@
     },
     "../../ui": {
       "name": "tc-helps-ui",
-      "version": "7.4.4",
+      "version": "7.4.5",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.1",
         "@neoconfetti/svelte": "^2.0.0",

--- a/src/config/functionalDataFetchers.ts
+++ b/src/config/functionalDataFetchers.ts
@@ -18,6 +18,7 @@ import {
 import {
   extractErrorMessage,
   extractErrorStatus,
+  extractErrorCode,
 } from "../utils/mcp-error-handler.js";
 import type { DataSourceConfig, EndpointConfig } from "./EndpointConfig.js";
 
@@ -193,11 +194,13 @@ export const createZIPFetcher = (
           // Extract error status if present
           const errorStatus = extractErrorStatus(error);
           const errorMessage = extractErrorMessage(error);
+          const errorCode = extractErrorCode(error);
 
           // If service threw an error, return appropriate HTTP error response
           const status = errorStatus || 500;
           const response = {
             error: errorMessage,
+            ...(errorCode ? { code: errorCode } : {}),
             citation: "",
             language,
             organization,
@@ -326,11 +329,13 @@ export const createZIPFetcher = (
           // Extract error status if present
           const errorStatus = extractErrorStatus(error);
           const errorMessage = extractErrorMessage(error);
+          const errorCode = extractErrorCode(error);
 
           // Return error response
           const status = errorStatus || 500;
           const response = {
             error: errorMessage,
+            ...(errorCode ? { code: errorCode } : {}),
             _metadata: {
               success: false,
               status,

--- a/src/contracts/ToolContracts.ts
+++ b/src/contracts/ToolContracts.ts
@@ -8,6 +8,12 @@ export interface MCPToolResponse {
     type: "text";
     text: string;
   }>;
+  /**
+   * MCP error flag. Omitted/false for normal results. A "resource not available"
+   * (404) outcome is returned with isError:false so consumers don't treat it as
+   * a server failure (issue #30).
+   */
+  isError?: boolean;
 }
 
 export interface ScriptureToolArgs {

--- a/src/functions/scripture-service.ts
+++ b/src/functions/scripture-service.ts
@@ -15,6 +15,7 @@ import { CacheBypassOptions } from "./unified-cache.js";
 import { EdgeXRayTracer } from "./edge-xray.js";
 import { ZipFetcherFactory } from "../services/zip-fetcher-provider.js";
 import { getBookCodesForError } from "../utils/book-codes.js";
+import { resourceNotAvailable } from "../utils/errorEnvelope.js";
 import {
   getPinnedOrganizationValue,
   isPinnedSingleOrganization,
@@ -183,8 +184,12 @@ export async function fetchScripture(
         organization: organization || "all",
         topic,
       });
-      throw new Error(
+      // Valid request, but the resource simply isn't published → 404, NOT a
+      // server failure. Keep the "No scripture resources found" wording so the
+      // language-variant fallback in ScriptureService still triggers (issue #30).
+      throw resourceNotAvailable(
         `No scripture resources found for ${language}${organization ? `/${organization}` : ""} with topic=${topic}`,
+        { requestedLanguage: language },
       );
     }
 

--- a/src/functions/translation-notes-service.ts
+++ b/src/functions/translation-notes-service.ts
@@ -5,6 +5,7 @@
  */
 
 import { logger } from "../utils/logger.js";
+import { resourceNotAvailable } from "../utils/errorEnvelope.js";
 import { proxyFetch } from "../utils/httpClient.js";
 import { parseReference } from "./reference-parser";
 import { getResourceForBook, getResourcesForBook } from "./resource-detector";
@@ -104,23 +105,21 @@ async function fetchTranslationNotesFromMultipleResources(
       ["TSV Translation Notes"],
     );
 
-    // Create structured error with recovery data
-    const error: any = new Error(
+    // Valid request, resource simply isn't published → 404 RESOURCE_NOT_AVAILABLE
+    // (issue #30), NOT a server failure.
+    const message =
       languageVariants.length > 0
         ? `No translation notes found for language '${language}'.\n\nAvailable language variants: ${languageVariants.join(", ")}\n\nPlease try one of these language codes instead.`
-        : `No translation notes available for language '${language}'.`,
-    );
+        : `No translation notes available for language '${language}'.`;
 
-    // Attach structured data for automatic retry
+    const extras: Record<string, unknown> = { requestedLanguage: language };
     if (languageVariants.length > 0) {
-      error.languageVariants = languageVariants;
-      error.requestedLanguage = language;
+      extras.languageVariants = languageVariants;
       logger.info("Throwing language variant error for translation notes", {
         language,
         variants: languageVariants,
       });
     } else {
-      error.requestedLanguage = language;
       logger.info(
         "Throwing language not supported error for translation notes",
         {
@@ -129,7 +128,7 @@ async function fetchTranslationNotesFromMultipleResources(
       );
     }
 
-    throw error;
+    throw resourceNotAvailable(message, extras);
   }
 
   logger.info(
@@ -376,17 +375,16 @@ export async function fetchTranslationNotes(
     // Filter out the current language to prevent infinite retry loops
     const filteredVariants = languageVariants.filter((v) => v !== language);
 
-    // Create structured error with recovery data
-    const error: any = new Error(
+    // Valid request, resource simply isn't published → 404 RESOURCE_NOT_AVAILABLE
+    // (issue #30), NOT a server failure.
+    const message =
       filteredVariants.length > 0
         ? `No translation notes found for language '${language}'.\n\nAvailable language variants: ${filteredVariants.join(", ")}\n\nPlease try one of these language codes instead.`
-        : `No translation notes available for language '${language}'.`,
-    );
+        : `No translation notes available for language '${language}'.`;
 
-    // Attach structured data for automatic retry
+    const extras: Record<string, unknown> = { requestedLanguage: language };
     if (filteredVariants.length > 0) {
-      error.languageVariants = filteredVariants;
-      error.requestedLanguage = language;
+      extras.languageVariants = filteredVariants;
       logger.info(
         "Throwing language variant error for translation notes (single org)",
         {
@@ -396,7 +394,6 @@ export async function fetchTranslationNotes(
         },
       );
     } else {
-      error.requestedLanguage = language;
       logger.info(
         "Throwing language not supported error for translation notes (single org)",
         {
@@ -406,7 +403,7 @@ export async function fetchTranslationNotes(
       );
     }
 
-    throw error;
+    throw resourceNotAvailable(message, extras);
   }
 
   logger.info(`Using resource`, {
@@ -434,8 +431,10 @@ export async function fetchTranslationNotes(
       book: parsedRef.book,
       ingredients: resourceInfo.ingredients,
     });
-    throw new Error(
+    // The resource exists but doesn't include this book → not available (404).
+    throw resourceNotAvailable(
       `Book ${parsedRef.book} not found in resource ${resourceInfo.name}`,
+      { requestedLanguage: language },
     );
   }
 

--- a/src/functions/translation-questions-service.ts
+++ b/src/functions/translation-questions-service.ts
@@ -5,6 +5,7 @@
  */
 
 import { logger } from "../utils/logger.js";
+import { resourceNotAvailable } from "../utils/errorEnvelope.js";
 import { parseReference } from "./reference-parser";
 import { getResourceForBook, getResourcesForBook } from "./resource-detector";
 import { ZipFetcherFactory } from "../services/zip-fetcher-provider.js";
@@ -92,23 +93,21 @@ async function fetchTranslationQuestionsFromMultipleResources(
       ["TSV Translation Questions"],
     );
 
-    // Create structured error with recovery data
-    const error: any = new Error(
+    // Valid request, resource simply isn't published → 404 RESOURCE_NOT_AVAILABLE
+    // (issues #30/#12), NOT a server failure.
+    const message =
       languageVariants.length > 0
         ? `No translation questions found for language '${language}'.\n\nAvailable language variants: ${languageVariants.join(", ")}\n\nPlease try one of these language codes instead.`
-        : `No translation questions available for language '${language}'.`,
-    );
+        : `No translation questions available for language '${language}'.`;
 
-    // Attach structured data for automatic retry
+    const extras: Record<string, unknown> = { requestedLanguage: language };
     if (languageVariants.length > 0) {
-      error.languageVariants = languageVariants;
-      error.requestedLanguage = language;
+      extras.languageVariants = languageVariants;
       logger.info("Throwing language variant error for translation questions", {
         language,
         variants: languageVariants,
       });
     } else {
-      error.requestedLanguage = language;
       logger.info(
         "Throwing language not supported error for translation questions",
         {
@@ -117,7 +116,7 @@ async function fetchTranslationQuestionsFromMultipleResources(
       );
     }
 
-    throw error;
+    throw resourceNotAvailable(message, extras);
   }
 
   logger.info(
@@ -317,17 +316,16 @@ export async function fetchTranslationQuestions(
     // Filter out the current language to prevent infinite retry loops
     const filteredVariants = languageVariants.filter((v) => v !== language);
 
-    // Create structured error with recovery data
-    const error: any = new Error(
+    // Valid request, resource simply isn't published → 404 RESOURCE_NOT_AVAILABLE
+    // (issues #30/#12), NOT a server failure.
+    const message =
       filteredVariants.length > 0
         ? `No translation questions found for language '${language}'.\n\nAvailable language variants: ${filteredVariants.join(", ")}\n\nPlease try one of these language codes instead.`
-        : `No translation questions available for language '${language}'.`,
-    );
+        : `No translation questions available for language '${language}'.`;
 
-    // Attach structured data for automatic retry
+    const extras: Record<string, unknown> = { requestedLanguage: language };
     if (filteredVariants.length > 0) {
-      error.languageVariants = filteredVariants;
-      error.requestedLanguage = language;
+      extras.languageVariants = filteredVariants;
       logger.info(
         "Throwing language variant error for translation questions (single org)",
         {
@@ -337,7 +335,6 @@ export async function fetchTranslationQuestions(
         },
       );
     } else {
-      error.requestedLanguage = language;
       logger.info(
         "Throwing language not supported error for translation questions (single org)",
         {
@@ -347,7 +344,7 @@ export async function fetchTranslationQuestions(
       );
     }
 
-    throw error;
+    throw resourceNotAvailable(message, extras);
   }
 
   logger.info(`Using resource`, {
@@ -375,8 +372,10 @@ export async function fetchTranslationQuestions(
       book: parsedRef.book,
       ingredients: resourceInfo.ingredients,
     });
-    throw new Error(
+    // The resource exists but doesn't include this book → not available (404).
+    throw resourceNotAvailable(
       `Book ${parsedRef.book} not found in resource ${resourceInfo.name}`,
+      { requestedLanguage: language },
     );
   }
 

--- a/src/tools/fetchScripture.ts
+++ b/src/tools/fetchScripture.ts
@@ -6,13 +6,21 @@
 
 import { z } from "zod";
 import { logger } from "../utils/logger.js";
-import { handleMCPError } from "../utils/mcp-error-handler.js";
+import {
+  handleMCPError,
+  buildResourceUnavailableResult,
+} from "../utils/mcp-error-handler.js";
 import { withPerformanceTracking } from "../utils/mcp-performance-tracker.js";
-import { createScriptureService, type ScriptureParams } from "../unified-services/index.js";
+import {
+  createScriptureService,
+  type ScriptureParams,
+} from "../unified-services/index.js";
 import { toZodObject, PARAMETER_GROUPS } from "../config/parameters/index.js";
 
 // Input schema - generated from unified parameter definitions
-export const FetchScriptureArgs = toZodObject(PARAMETER_GROUPS.scripture.parameters);
+export const FetchScriptureArgs = toZodObject(
+  PARAMETER_GROUPS.scripture.parameters,
+);
 
 export type FetchScriptureArgs = z.infer<typeof FetchScriptureArgs>;
 
@@ -30,13 +38,14 @@ export async function handleFetchScripture(args: FetchScriptureArgs) {
         // Create and execute unified service
         const service = createScriptureService();
         const response = await service.execute(args as ScriptureParams, {
-          platform: 'mcp',
+          platform: "mcp",
         });
 
         // Format response for MCP
-        const textContent = typeof response.data === 'string' 
-          ? response.data 
-          : JSON.stringify(response.data, null, 2);
+        const textContent =
+          typeof response.data === "string"
+            ? response.data
+            : JSON.stringify(response.data, null, 2);
 
         return {
           content: [
@@ -49,6 +58,18 @@ export async function handleFetchScripture(args: FetchScriptureArgs) {
           ...(response.metadata && { metadata: response.metadata }),
         };
       } catch (error: any) {
+        // A not-available resource (404) is an expected result, not a failure:
+        // return it as a normal (isError:false) result so downstream consumers
+        // don't treat it as a server outage (issue #30).
+        const notAvailable = buildResourceUnavailableResult(error);
+        if (notAvailable) {
+          logger.info("Scripture resource not available", {
+            args,
+            message: error?.message,
+          });
+          return notAvailable;
+        }
+
         logger.error("Failed to fetch scripture", { error, args });
         return handleMCPError({
           toolName: "fetch_scripture",

--- a/src/tools/fetchTranslationNotes.ts
+++ b/src/tools/fetchTranslationNotes.ts
@@ -6,14 +6,24 @@
 
 import { z } from "zod";
 import { logger } from "../utils/logger.js";
-import { handleMCPError } from "../utils/mcp-error-handler.js";
-import { createTranslationNotesService, type TranslationNotesParams } from "../unified-services/index.js";
+import {
+  handleMCPError,
+  buildResourceUnavailableResult,
+} from "../utils/mcp-error-handler.js";
+import {
+  createTranslationNotesService,
+  type TranslationNotesParams,
+} from "../unified-services/index.js";
 import { toZodObject, PARAMETER_GROUPS } from "../config/parameters/index.js";
 
 // Input schema - generated from unified parameter definitions
-export const FetchTranslationNotesArgs = toZodObject(PARAMETER_GROUPS.translationNotes.parameters);
+export const FetchTranslationNotesArgs = toZodObject(
+  PARAMETER_GROUPS.translationNotes.parameters,
+);
 
-export type FetchTranslationNotesArgs = z.infer<typeof FetchTranslationNotesArgs>;
+export type FetchTranslationNotesArgs = z.infer<
+  typeof FetchTranslationNotesArgs
+>;
 
 /**
  * Handle the fetch translation notes tool call
@@ -28,13 +38,14 @@ export async function handleFetchTranslationNotes(
     // Create and execute unified service
     const service = createTranslationNotesService();
     const response = await service.execute(args as TranslationNotesParams, {
-      platform: 'mcp',
+      platform: "mcp",
     });
 
     // Format response for MCP
-    const textContent = typeof response.data === 'string' 
-      ? response.data 
-      : JSON.stringify(response.data, null, 2);
+    const textContent =
+      typeof response.data === "string"
+        ? response.data
+        : JSON.stringify(response.data, null, 2);
 
     return {
       content: [
@@ -47,6 +58,16 @@ export async function handleFetchTranslationNotes(
       ...(response.metadata && { metadata: response.metadata }),
     };
   } catch (error: any) {
+    // A not-available resource (404) is an expected result, not a failure (issue #30).
+    const notAvailable = buildResourceUnavailableResult(error);
+    if (notAvailable) {
+      logger.info("Translation notes resource not available", {
+        args,
+        message: error?.message,
+      });
+      return notAvailable;
+    }
+
     logger.error("Failed to fetch translation notes", { error, args });
     return handleMCPError({
       toolName: "fetch_translation_notes",

--- a/src/tools/fetchTranslationQuestions.ts
+++ b/src/tools/fetchTranslationQuestions.ts
@@ -6,14 +6,24 @@
 
 import { z } from "zod";
 import { logger } from "../utils/logger.js";
-import { handleMCPError } from "../utils/mcp-error-handler.js";
-import { createTranslationQuestionsService, type TranslationQuestionsParams } from "../unified-services/index.js";
+import {
+  handleMCPError,
+  buildResourceUnavailableResult,
+} from "../utils/mcp-error-handler.js";
+import {
+  createTranslationQuestionsService,
+  type TranslationQuestionsParams,
+} from "../unified-services/index.js";
 import { toZodObject, PARAMETER_GROUPS } from "../config/parameters/index.js";
 
 // Input schema - generated from unified parameter definitions
-export const FetchTranslationQuestionsArgs = toZodObject(PARAMETER_GROUPS.translationQuestions.parameters);
+export const FetchTranslationQuestionsArgs = toZodObject(
+  PARAMETER_GROUPS.translationQuestions.parameters,
+);
 
-export type FetchTranslationQuestionsArgs = z.infer<typeof FetchTranslationQuestionsArgs>;
+export type FetchTranslationQuestionsArgs = z.infer<
+  typeof FetchTranslationQuestionsArgs
+>;
 
 /**
  * Handle the fetch translation questions tool call
@@ -28,13 +38,14 @@ export async function handleFetchTranslationQuestions(
     // Create and execute unified service
     const service = createTranslationQuestionsService();
     const response = await service.execute(args as TranslationQuestionsParams, {
-      platform: 'mcp',
+      platform: "mcp",
     });
 
     // Format response for MCP
-    const textContent = typeof response.data === 'string' 
-      ? response.data 
-      : JSON.stringify(response.data, null, 2);
+    const textContent =
+      typeof response.data === "string"
+        ? response.data
+        : JSON.stringify(response.data, null, 2);
 
     return {
       content: [
@@ -47,6 +58,16 @@ export async function handleFetchTranslationQuestions(
       ...(response.metadata && { metadata: response.metadata }),
     };
   } catch (error: any) {
+    // A not-available resource (404) is an expected result, not a failure (issue #30/#12).
+    const notAvailable = buildResourceUnavailableResult(error);
+    if (notAvailable) {
+      logger.info("Translation questions resource not available", {
+        args,
+        message: error?.message,
+      });
+      return notAvailable;
+    }
+
     logger.error("Failed to fetch translation questions", { error, args });
     return handleMCPError({
       toolName: "fetch_translation_questions",

--- a/src/unified-services/BaseService.ts
+++ b/src/unified-services/BaseService.ts
@@ -1,16 +1,16 @@
 /**
  * Base Service Class
- * 
+ *
  * Provides common functionality for all unified services
  */
 
-import type { UnifiedParameterDef } from '../config/parameters/index.js';
+import type { UnifiedParameterDef } from "../config/parameters/index.js";
 import type {
   UnifiedService,
   ServiceResponse,
   ServiceError,
   ServiceContext,
-} from './types.js';
+} from "./types.js";
 
 /**
  * Base class for unified services
@@ -27,7 +27,7 @@ export abstract class BaseService<TParams = any, TResult = any>
    */
   abstract execute(
     params: TParams,
-    context?: ServiceContext
+    context?: ServiceContext,
   ): Promise<ServiceResponse<TResult>>;
 
   /**
@@ -35,8 +35,8 @@ export abstract class BaseService<TParams = any, TResult = any>
    */
   protected success(
     data: TResult,
-    metadata?: ServiceResponse['metadata'],
-    format?: ServiceResponse['format']
+    metadata?: ServiceResponse["metadata"],
+    format?: ServiceResponse["format"],
   ): ServiceResponse<TResult> {
     return {
       data,
@@ -52,7 +52,7 @@ export abstract class BaseService<TParams = any, TResult = any>
     code: string,
     message: string,
     details?: any,
-    status?: number
+    status?: number,
   ): ServiceError {
     const error: ServiceError = {
       code,
@@ -62,7 +62,7 @@ export abstract class BaseService<TParams = any, TResult = any>
     };
 
     // Include stack trace in development
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === "development") {
       error.stack = new Error().stack;
     }
 
@@ -72,55 +72,79 @@ export abstract class BaseService<TParams = any, TResult = any>
   /**
    * Handle errors consistently
    */
-  protected handleError(error: any, context?: ServiceContext): ServiceError {
+  protected handleError(error: any, _context?: ServiceContext): ServiceError {
     // If it's already a ServiceError, return it
     if (this.isServiceError(error)) {
       return error;
     }
 
-    // Handle common error types
-    if (error.message?.includes('404') || error.message?.includes('not found')) {
-      return this.error('NOT_FOUND', error.message || 'Resource not found', error, 404);
-    }
-
-    if (error.message?.includes('401') || error.message?.includes('unauthorized')) {
+    // Resource-not-available (issue #30): an unpublished/unavailable resource is
+    // a 404, NOT a server failure. Match before the substring branches below so
+    // it can never be downgraded to INTERNAL_ERROR/500 (its message — e.g.
+    // "No scripture resources found" — contains neither "404" nor "not found").
+    if (error?.code === "RESOURCE_NOT_AVAILABLE") {
       return this.error(
-        'UNAUTHORIZED',
-        error.message || 'Unauthorized access',
+        "RESOURCE_NOT_AVAILABLE",
+        error.message || "Resource not available",
         error,
-        401
+        404,
       );
     }
 
-    if (error.message?.includes('timeout')) {
+    // Handle common error types
+    if (
+      error.message?.includes("404") ||
+      error.message?.includes("not found")
+    ) {
       return this.error(
-        'TIMEOUT',
-        error.message || 'Request timeout',
+        "NOT_FOUND",
+        error.message || "Resource not found",
         error,
-        504
+        404,
+      );
+    }
+
+    if (
+      error.message?.includes("401") ||
+      error.message?.includes("unauthorized")
+    ) {
+      return this.error(
+        "UNAUTHORIZED",
+        error.message || "Unauthorized access",
+        error,
+        401,
+      );
+    }
+
+    if (error.message?.includes("timeout")) {
+      return this.error(
+        "TIMEOUT",
+        error.message || "Request timeout",
+        error,
+        504,
       );
     }
 
     // Handle invalid reference/book code errors (400 Bad Request)
     if (
-      error.message?.includes('Invalid reference') ||
-      error.message?.includes('book code') ||
-      error.message?.includes('3-letter')
+      error.message?.includes("Invalid reference") ||
+      error.message?.includes("book code") ||
+      error.message?.includes("3-letter")
     ) {
       return this.error(
-        'INVALID_REFERENCE',
-        error.message || 'Invalid reference format',
+        "INVALID_REFERENCE",
+        error.message || "Invalid reference format",
         error,
-        400
+        400,
       );
     }
 
     // Generic error
     return this.error(
-      'INTERNAL_ERROR',
-      error.message || 'An unexpected error occurred',
+      "INTERNAL_ERROR",
+      error.message || "An unexpected error occurred",
       error,
-      500
+      500,
     );
   }
 
@@ -128,7 +152,9 @@ export abstract class BaseService<TParams = any, TResult = any>
    * Check if an object is a ServiceError
    */
   private isServiceError(obj: any): obj is ServiceError {
-    return obj && typeof obj.code === 'string' && typeof obj.message === 'string';
+    return (
+      obj && typeof obj.code === "string" && typeof obj.message === "string"
+    );
   }
 
   /**
@@ -136,13 +162,13 @@ export abstract class BaseService<TParams = any, TResult = any>
    */
   protected async withTiming<T>(
     fn: () => Promise<T>,
-    label?: string
+    label?: string,
   ): Promise<{ result: T; elapsed: number }> {
     const start = performance.now();
     const result = await fn();
     const elapsed = Math.round(performance.now() - start);
 
-    if (label && process.env.NODE_ENV === 'development') {
+    if (label && process.env.NODE_ENV === "development") {
       console.log(`[${this.name}] ${label}: ${elapsed}ms`);
     }
 
@@ -159,7 +185,10 @@ export abstract class BaseService<TParams = any, TResult = any>
       const value = params[param.name];
 
       // Check required parameters
-      if (param.required && (value === undefined || value === null || value === '')) {
+      if (
+        param.required &&
+        (value === undefined || value === null || value === "")
+      ) {
         errors.push(`Missing required parameter: ${param.name}`);
         continue;
       }
@@ -171,10 +200,10 @@ export abstract class BaseService<TParams = any, TResult = any>
 
       // Type validation
       if (value !== undefined && value !== null) {
-        const actualType = Array.isArray(value) ? 'array' : typeof value;
-        if (param.type !== actualType && param.type !== 'object') {
+        const actualType = Array.isArray(value) ? "array" : typeof value;
+        if (param.type !== actualType && param.type !== "object") {
           errors.push(
-            `Invalid type for ${param.name}: expected ${param.type}, got ${actualType}`
+            `Invalid type for ${param.name}: expected ${param.type}, got ${actualType}`,
           );
         }
       }
@@ -184,9 +213,9 @@ export abstract class BaseService<TParams = any, TResult = any>
         const validationResult = param.validate(value);
         if (validationResult !== true) {
           errors.push(
-            typeof validationResult === 'string'
+            typeof validationResult === "string"
               ? validationResult
-              : `Validation failed for ${param.name}`
+              : `Validation failed for ${param.name}`,
           );
         }
       }

--- a/src/utils/errorEnvelope.ts
+++ b/src/utils/errorEnvelope.ts
@@ -25,6 +25,71 @@ export function errorEnvelope(
   return env;
 }
 
+/**
+ * Stable, machine-readable code signalling that a requested resource exists
+ * conceptually (valid book/language) but is simply not published/available.
+ *
+ * Consumers (e.g. bt-servant-worker) MUST treat this as an expected
+ * "not available" outcome — NOT a server outage. See issue #30.
+ */
+export const RESOURCE_NOT_AVAILABLE = "RESOURCE_NOT_AVAILABLE" as const;
+
+/**
+ * A plain Error carrying a stable `code` + HTTP `status` (+ optional `type`).
+ *
+ * We attach these as duck-typed properties rather than using an Error subclass
+ * because errors cross dynamic `await import(...)` module boundaries throughout
+ * the services, where `instanceof` checks are unreliable. The rest of the
+ * codebase already reads `.status`/`.code` off plain Errors (see
+ * extractErrorStatus / BaseService.isServiceError).
+ */
+export interface AppError extends Error {
+  code?: string;
+  status?: number;
+  type?: string;
+  // Preserved retry-hint fields used by the resource services
+  languageVariants?: string[];
+  requestedLanguage?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Build a plain Error carrying a stable code + HTTP status + type.
+ * Any `extras` (e.g. languageVariants, requestedLanguage) are attached verbatim.
+ */
+export function makeCodedError(
+  message: string,
+  opts: {
+    code: string;
+    status: number;
+    type?: string;
+    extras?: Record<string, unknown>;
+  },
+): AppError {
+  const err = new Error(message) as AppError;
+  err.code = opts.code;
+  err.status = opts.status;
+  err.type = opts.type ?? "NOT_AVAILABLE";
+  if (opts.extras) Object.assign(err, opts.extras);
+  return err;
+}
+
+/**
+ * Build a RESOURCE_NOT_AVAILABLE (HTTP 404) error for an unpublished/unavailable
+ * resource. Distinct from an INVALID reference/book code (which stays 400).
+ */
+export function resourceNotAvailable(
+  message: string,
+  extras?: Record<string, unknown>,
+): AppError {
+  return makeCodedError(message, {
+    code: RESOURCE_NOT_AVAILABLE,
+    status: 404,
+    type: "NOT_AVAILABLE",
+    extras,
+  });
+}
+
 export const Errors = {
   missingParameter(param: string, traceId?: string): ErrorEnvelope {
     return errorEnvelope(
@@ -50,6 +115,14 @@ export const Errors = {
       hint: "Try again. If the issue persists, contact support.",
       traceId,
       type: "INTERNAL_ERROR",
+    });
+  },
+
+  resourceNotAvailable(message: string, traceId?: string): ErrorEnvelope {
+    return errorEnvelope(RESOURCE_NOT_AVAILABLE, message, {
+      hint: "This resource is not published for the requested language/organization. It is not a server outage.",
+      type: "NOT_AVAILABLE",
+      traceId,
     });
   },
 };

--- a/src/utils/mcp-error-handler.ts
+++ b/src/utils/mcp-error-handler.ts
@@ -6,7 +6,7 @@
  */
 
 import { logger } from "./logger.js";
-import { buildMetadata } from "./metadata-builder.js";
+import { RESOURCE_NOT_AVAILABLE } from "./errorEnvelope.js";
 
 /**
  * Extract error message from unknown error type
@@ -23,16 +23,88 @@ export function extractErrorMessage(error: unknown): string {
 }
 
 /**
- * Extract HTTP status code from error if present
+ * Extract HTTP status code from error if present.
+ * Handles both Error instances and plain ServiceError-shaped objects.
  */
 export function extractErrorStatus(error: unknown): number | undefined {
-  if (error instanceof Error && "status" in error) {
-    const status = (error as Error & { status?: number }).status;
+  if (error && typeof error === "object" && "status" in error) {
+    const status = (error as { status?: unknown }).status;
     if (typeof status === "number" && status >= 400 && status < 600) {
       return status;
     }
   }
   return undefined;
+}
+
+/**
+ * Extract a stable error code from error if present.
+ * Handles both Error instances and plain ServiceError-shaped objects.
+ */
+export function extractErrorCode(error: unknown): string | undefined {
+  if (error && typeof error === "object" && "code" in error) {
+    const code = (error as { code?: unknown }).code;
+    if (typeof code === "string") return code;
+  }
+  return undefined;
+}
+
+/**
+ * Keys carrying caller-facing retry hints that should survive on a
+ * "resource not available" result (so the model can suggest alternatives).
+ */
+const RETRY_HINT_KEYS = [
+  "languageVariants",
+  "requestedLanguage",
+  "availableVariants",
+  "suggestion",
+  "validBookCodes",
+] as const;
+
+/**
+ * If the error represents a "resource not available" condition (HTTP 404 family
+ * — e.g. an unpublished resource or an unavailable language) rather than a
+ * server failure, return a NORMAL (isError:false) MCP result describing the
+ * unavailability. Otherwise return null so the caller falls back to
+ * handleMCPError (isError:true).
+ *
+ * This is the crux of issue #30: a not-available response must NOT look like a
+ * tool error, because bt-servant-worker converts any isError:true into a health
+ * failure that, after 3 strikes, reports the server as "down".
+ */
+export function buildResourceUnavailableResult(
+  error: unknown,
+): MCPErrorResponse | null {
+  const status = extractErrorStatus(error);
+  const code = extractErrorCode(error);
+  const isNotAvailable = status === 404 || code === RESOURCE_NOT_AVAILABLE;
+  if (!isNotAvailable) return null;
+
+  const message = extractErrorMessage(error);
+
+  const payload: Record<string, unknown> = {
+    available: false,
+    code: code || RESOURCE_NOT_AVAILABLE,
+    status: status || 404,
+    message,
+  };
+
+  if (error && typeof error === "object") {
+    const e = error as Record<string, unknown>;
+    if (e.details !== undefined) payload.details = e.details;
+    for (const key of RETRY_HINT_KEYS) {
+      if (e[key] !== undefined) payload[key] = e[key];
+    }
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+    isError: false,
+  };
 }
 
 export interface MCPErrorResponse {
@@ -95,6 +167,9 @@ export function handleMCPError(context: ErrorContext): MCPErrorResponse {
       ? originalError.message
       : String(originalError);
 
+  const code = extractErrorCode(originalError);
+  const status = extractErrorStatus(originalError);
+
   const responseTime = Date.now() - startTime;
 
   // Log error with full context
@@ -102,6 +177,8 @@ export function handleMCPError(context: ErrorContext): MCPErrorResponse {
     ...args,
     ...additionalContext,
     error: errorMessage,
+    ...(code ? { code } : {}),
+    ...(status ? { status } : {}),
     responseTime,
     timestamp: new Date().toISOString(),
     // Include stack trace if available
@@ -118,6 +195,8 @@ export function handleMCPError(context: ErrorContext): MCPErrorResponse {
         text: JSON.stringify(
           {
             error: errorMessage,
+            ...(code ? { code } : {}),
+            ...(status ? { status } : {}),
             tool: toolName,
             timestamp: new Date().toISOString(),
             responseTime,

--- a/src/utils/mcp-error-handler.ts
+++ b/src/utils/mcp-error-handler.ts
@@ -19,6 +19,15 @@ export function extractErrorMessage(error: unknown): string {
   if (typeof error === "string") {
     return error;
   }
+  // Plain ServiceError-shaped objects ({code, message, status}) carry the
+  // message as a property — read it rather than stringifying to "[object Object]".
+  if (
+    error &&
+    typeof error === "object" &&
+    typeof (error as { message?: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message;
+  }
   return String(error);
 }
 
@@ -67,6 +76,15 @@ const RETRY_HINT_KEYS = [
 ] as const;
 
 /**
+ * Some endpoints append a verbose `(Trace: {...})` X-ray blob to their error
+ * MESSAGE (e.g. fetch-translation-word/-academy routes). That diagnostic must
+ * not ride along in the model-facing "not available" result (PR #31 review).
+ */
+export function stripInlineDiagnostics(message: string): string {
+  return message.replace(/\s*\(Trace:\s*\{[\s\S]*\}\)\s*$/, "").trim();
+}
+
+/**
  * If the error represents a "resource not available" condition (HTTP 404 family
  * — e.g. an unpublished resource or an unavailable language) rather than a
  * server failure, return a NORMAL (isError:false) MCP result describing the
@@ -85,7 +103,7 @@ export function buildResourceUnavailableResult(
   const isNotAvailable = status === 404 || code === RESOURCE_NOT_AVAILABLE;
   if (!isNotAvailable) return null;
 
-  const message = extractErrorMessage(error);
+  const message = stripInlineDiagnostics(extractErrorMessage(error));
 
   const payload: Record<string, unknown> = {
     available: false,

--- a/src/utils/mcp-error-handler.ts
+++ b/src/utils/mcp-error-handler.ts
@@ -49,15 +49,21 @@ export function extractErrorCode(error: unknown): string | undefined {
 }
 
 /**
- * Keys carrying caller-facing retry hints that should survive on a
+ * Keys carrying caller-facing recovery hints that should survive on a
  * "resource not available" result (so the model can suggest alternatives).
+ * This is an allowlist: anything NOT here (stack, endpoint/path/params,
+ * timestamps, traces) must never leak into the model-facing result (PR #31).
  */
 const RETRY_HINT_KEYS = [
   "languageVariants",
   "requestedLanguage",
   "availableVariants",
+  "baseLanguage",
   "suggestion",
   "validBookCodes",
+  "invalidCode",
+  "availableBooks",
+  "toc",
 ] as const;
 
 /**
@@ -88,11 +94,18 @@ export function buildResourceUnavailableResult(
     message,
   };
 
+  // Promote only allowlisted recovery hints — from the top level OR nested in a
+  // `details` object — and never the raw `details` blob (which may carry a stack
+  // trace or other diagnostics). See PR #31 review.
   if (error && typeof error === "object") {
     const e = error as Record<string, unknown>;
-    if (e.details !== undefined) payload.details = e.details;
+    const nested =
+      e.details && typeof e.details === "object"
+        ? (e.details as Record<string, unknown>)
+        : {};
     for (const key of RETRY_HINT_KEYS) {
-      if (e[key] !== undefined) payload[key] = e[key];
+      const value = e[key] !== undefined ? e[key] : nested[key];
+      if (value !== undefined) payload[key] = value;
     }
   }
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -3,7 +3,7 @@
  * SINGLE SOURCE OF TRUTH for server version. Do not edit manually.
  */
 
-export const VERSION = "7.4.4";
+export const VERSION = "7.4.5";
 
 export function getVersion(): string {
   return VERSION;

--- a/tests/coded-errors.test.ts
+++ b/tests/coded-errors.test.ts
@@ -109,7 +109,30 @@ describe("buildResourceUnavailableResult", () => {
     expect(result!.isError).toBe(false);
     const body = JSON.parse(result!.content![0].text);
     expect(body.code).toBe("LANGUAGE_NOT_FOUND");
-    expect(body.details).toEqual({ availableVariants: ["es-419"] });
+    // Recovery hints are promoted out of nested `details` to the top level…
+    expect(body.availableVariants).toEqual(["es-419"]);
+  });
+
+  it("never leaks the raw details blob (no stack / endpoint / params)", () => {
+    const svcErr = {
+      code: "RESOURCE_NOT_AVAILABLE",
+      message: "nope",
+      status: 404,
+      details: {
+        stack: ["Error: nope", "  at foo"],
+        endpoint: "fetch-scripture-v2",
+        params: { reference: "JHN 3:16" },
+        requestedLanguage: "qaa",
+      },
+    };
+    const result = buildResourceUnavailableResult(svcErr);
+    const body = JSON.parse(result!.content![0].text);
+    expect(body.details).toBeUndefined();
+    expect(body.stack).toBeUndefined();
+    expect(body.endpoint).toBeUndefined();
+    expect(body.params).toBeUndefined();
+    // …but allowlisted recovery hints still come through.
+    expect(body.requestedLanguage).toBe("qaa");
   });
 
   it("returns null for a genuine failure (no 404 / not-available code)", () => {

--- a/tests/coded-errors.test.ts
+++ b/tests/coded-errors.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Coded "resource not available" errors (issue #30 / #12)
+ *
+ * Deterministic unit tests (no live server) that lock in the contract:
+ * an unpublished/unavailable resource must surface as a stable
+ * RESOURCE_NOT_AVAILABLE / HTTP 404 signal — NOT a generic 500 / server error —
+ * and the MCP tool layer must return it as a NORMAL (isError:false) result so
+ * downstream consumers don't treat it as a server outage.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resourceNotAvailable,
+  makeCodedError,
+  RESOURCE_NOT_AVAILABLE,
+} from "../src/utils/errorEnvelope.js";
+import {
+  extractErrorStatus,
+  extractErrorCode,
+  buildResourceUnavailableResult,
+} from "../src/utils/mcp-error-handler.js";
+import { BaseService } from "../src/unified-services/BaseService.js";
+
+// Minimal concrete BaseService to exercise the protected handleError().
+class TestService extends BaseService {
+  name = "test";
+  description = "test";
+  parameters = [];
+  async execute() {
+    return this.success({} as any);
+  }
+  public callHandleError(error: any) {
+    return this.handleError(error);
+  }
+}
+
+describe("resourceNotAvailable factory", () => {
+  it("produces an Error carrying code, status 404 and type", () => {
+    const err = resourceNotAvailable("Psalms not published");
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("Psalms not published");
+    expect(err.code).toBe(RESOURCE_NOT_AVAILABLE);
+    expect(err.status).toBe(404);
+    expect(err.type).toBe("NOT_AVAILABLE");
+  });
+
+  it("preserves retry-hint extras (languageVariants, requestedLanguage)", () => {
+    const err = resourceNotAvailable("No notes for xyz", {
+      languageVariants: ["es-419", "es"],
+      requestedLanguage: "xyz",
+    });
+    expect(err.languageVariants).toEqual(["es-419", "es"]);
+    expect(err.requestedLanguage).toBe("xyz");
+  });
+
+  it("makeCodedError supports arbitrary code/status", () => {
+    const err = makeCodedError("nope", { code: "WORD_NOT_FOUND", status: 404 });
+    expect(err.code).toBe("WORD_NOT_FOUND");
+    expect(err.status).toBe(404);
+  });
+});
+
+describe("extractErrorStatus / extractErrorCode", () => {
+  it("reads status/code off a coded Error instance", () => {
+    const err = resourceNotAvailable("x");
+    expect(extractErrorStatus(err)).toBe(404);
+    expect(extractErrorCode(err)).toBe(RESOURCE_NOT_AVAILABLE);
+  });
+
+  it("reads status/code off a plain ServiceError-shaped object", () => {
+    const svcErr = { code: "LANGUAGE_NOT_FOUND", message: "no", status: 404 };
+    expect(extractErrorStatus(svcErr)).toBe(404);
+    expect(extractErrorCode(svcErr)).toBe("LANGUAGE_NOT_FOUND");
+  });
+
+  it("ignores out-of-range / missing values", () => {
+    expect(extractErrorStatus(new Error("plain"))).toBeUndefined();
+    expect(extractErrorCode(new Error("plain"))).toBeUndefined();
+    expect(extractErrorStatus({ status: 200 })).toBeUndefined();
+  });
+});
+
+describe("buildResourceUnavailableResult", () => {
+  it("returns a NON-error MCP result for a RESOURCE_NOT_AVAILABLE error", () => {
+    const err = resourceNotAvailable("No scripture resources found for en", {
+      requestedLanguage: "en",
+    });
+    const result = buildResourceUnavailableResult(err);
+    expect(result).not.toBeNull();
+    expect(result!.isError).toBe(false);
+
+    const body = JSON.parse(result!.content![0].text);
+    expect(body.available).toBe(false);
+    expect(body.code).toBe(RESOURCE_NOT_AVAILABLE);
+    expect(body.status).toBe(404);
+    expect(body.message).toMatch(/No scripture resources found/);
+    expect(body.requestedLanguage).toBe("en");
+  });
+
+  it("treats any 404-status error (e.g. LANGUAGE_NOT_FOUND) as not-available", () => {
+    const svcErr = {
+      code: "LANGUAGE_NOT_FOUND",
+      message: "Try es-419",
+      status: 404,
+      details: { availableVariants: ["es-419"] },
+    };
+    const result = buildResourceUnavailableResult(svcErr);
+    expect(result).not.toBeNull();
+    expect(result!.isError).toBe(false);
+    const body = JSON.parse(result!.content![0].text);
+    expect(body.code).toBe("LANGUAGE_NOT_FOUND");
+    expect(body.details).toEqual({ availableVariants: ["es-419"] });
+  });
+
+  it("returns null for a genuine failure (no 404 / not-available code)", () => {
+    expect(buildResourceUnavailableResult(new Error("boom"))).toBeNull();
+    expect(
+      buildResourceUnavailableResult({ code: "INTERNAL_ERROR", status: 500 }),
+    ).toBeNull();
+  });
+});
+
+describe("BaseService.handleError mapping", () => {
+  it("maps a RESOURCE_NOT_AVAILABLE error to 404 (never downgrades to 500)", () => {
+    const svc = new TestService();
+    // Message intentionally lacks the substrings "404"/"not found" — exactly the
+    // case that previously fell through to INTERNAL_ERROR/500.
+    const err = resourceNotAvailable(
+      "No scripture resources found for en with topic=tc-ready",
+    );
+    const mapped = svc.callHandleError(err);
+    expect(mapped.code).toBe(RESOURCE_NOT_AVAILABLE);
+    expect(mapped.status).toBe(404);
+  });
+
+  it("still maps an unknown error to INTERNAL_ERROR/500", () => {
+    const svc = new TestService();
+    const mapped = svc.callHandleError(new Error("totally unexpected"));
+    expect(mapped.code).toBe("INTERNAL_ERROR");
+    expect(mapped.status).toBe(500);
+  });
+});

--- a/tests/coded-errors.test.ts
+++ b/tests/coded-errors.test.ts
@@ -135,6 +135,23 @@ describe("buildResourceUnavailableResult", () => {
     expect(body.requestedLanguage).toBe("qaa");
   });
 
+  it("strips an inline (Trace: {...}) blob from the message", () => {
+    const err = {
+      code: "RESOURCE_NOT_AVAILABLE",
+      status: 404,
+      message:
+        "Translation word 'xyz' not found.\n\nPlease try one of these instead. " +
+        '(Trace: {"traceId":"tw-1","apiCalls":[{"url":"internal://x","status":404}]})',
+    };
+    const body = JSON.parse(
+      buildResourceUnavailableResult(err)!.content![0].text,
+    );
+    expect(body.message).toBe(
+      "Translation word 'xyz' not found.\n\nPlease try one of these instead.",
+    );
+    expect(body.message).not.toMatch(/Trace:/);
+  });
+
   it("returns null for a genuine failure (no 404 / not-available code)", () => {
     expect(buildResourceUnavailableResult(new Error("boom"))).toBeNull();
     expect(

--- a/tests/error-handling.test.ts
+++ b/tests/error-handling.test.ts
@@ -157,62 +157,77 @@ describe("Error Handling Tests", () => {
     });
   });
 
-  describe("Resource Not Found (404 errors)", () => {
-    it("should return 404 for non-existent language", async () => {
-      let mcpError: string = "";
-      let restError: string = "";
+  describe("Resource Not Available (404 / RESOURCE_NOT_AVAILABLE)", () => {
+    // Issue #30 / #12: an unavailable resource must surface as a 404 +
+    // RESOURCE_NOT_AVAILABLE on REST, and as a NON-error (isError:false)
+    // structured result on MCP — never as a generic error that downstream
+    // consumers read as "the server is down".
 
+    /** Parse an MCP tool result's JSON text payload. */
+    function parseMCP(res: any): any {
+      const text = res?.content?.[0]?.text ?? "";
       try {
-        await client.callMCPTool({
-          name: "fetch_scripture",
-          arguments: {
-            reference: TEST_DATA.references.singleVerse,
-            language: TEST_DATA.languages.invalid,
-          },
-        });
-      } catch (error: any) {
-        mcpError = error.message;
+        return JSON.parse(text);
+      } catch {
+        return { _raw: text };
       }
+    }
 
-      try {
-        await client.callREST("fetch-scripture", {
+    it("returns a NON-error 'not available' MCP result for an unavailable language (scripture)", async () => {
+      const res = await client.callMCPTool({
+        name: "fetch_scripture",
+        arguments: {
           reference: TEST_DATA.references.singleVerse,
           language: TEST_DATA.languages.invalid,
-        });
-      } catch (error: any) {
-        restError = error.message;
-      }
+        },
+      });
 
-      // Both should fail
-      expect(mcpError).toBeTruthy();
-      expect(restError).toBeTruthy();
-
-      // Unresolvable language may be 404 upstream or 400 invalid parameter
-      expect(mcpError.toLowerCase()).toMatch(
-        /not found|404|invalid|language|parameter|scripture/,
-      );
-      expect(restError.toLowerCase()).toMatch(
-        /not found|404|invalid|language|parameter|scripture/,
-      );
+      // Must NOT be flagged as a tool error (that trips the worker health circuit)
+      expect(res.isError, "not-available must not be an MCP error").toBe(false);
+      const body = parseMCP(res);
+      expect(body.available).toBe(false);
+      expect(body.status).toBe(404);
+      expect(typeof body.code).toBe("string");
     });
 
-    it("should return 404 for non-existent resource path", async () => {
-      let mcpError: string = "";
+    it("returns HTTP 404 + code via REST for an unavailable language (scripture)", async () => {
+      const { status, data } = await client.callRESTRaw("fetch-scripture", {
+        reference: TEST_DATA.references.singleVerse,
+        language: TEST_DATA.languages.invalid,
+      });
 
-      try {
-        await client.callMCPTool({
-          name: "fetch_translation_word",
-          arguments: {
-            path: "kt/nonexistent-word-xyz123",
-            language: "en",
-          },
-        });
-      } catch (error: any) {
-        mcpError = error.message;
-      }
+      expect(status).toBe(404);
+      expect(data?.code).toBe("RESOURCE_NOT_AVAILABLE");
+      expect(data?.status ?? data?._metadata?.status).toBe(404);
+    });
 
-      expect(mcpError).toBeTruthy();
-      expect(mcpError.toLowerCase()).toMatch(/not found|404/);
+    it("returns a NON-error 'not available' MCP result for unavailable translation questions (#12)", async () => {
+      const res = await client.callMCPTool({
+        name: "fetch_translation_questions",
+        arguments: {
+          reference: TEST_DATA.references.singleVerse,
+          language: TEST_DATA.languages.invalid,
+        },
+      });
+
+      expect(res.isError).toBe(false);
+      const body = parseMCP(res);
+      expect(body.available).toBe(false);
+      expect(body.status).toBe(404);
+    });
+
+    it("does not 5xx for a non-existent reference (no false 'server down')", async () => {
+      // A bad/unknown reference must resolve to a 4xx client outcome, never a
+      // 5xx that downstream would read as a server outage. (The precise
+      // 400-invalid-vs-404-not-available split is asserted deterministically in
+      // tests/coded-errors.test.ts against BaseService.handleError.)
+      const { status } = await client.callRESTRaw("fetch-scripture", {
+        reference: "NotARealBook 1:1",
+        language: "en",
+      });
+
+      expect(status).toBeGreaterThanOrEqual(400);
+      expect(status).toBeLessThan(500);
     });
   });
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "tc-helps-ui",
-	"version": "7.4.4",
+	"version": "7.4.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "tc-helps-ui",
-			"version": "7.4.4",
+			"version": "7.4.5",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.15.1",
 				"@neoconfetti/svelte": "^2.0.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "tc-helps-ui",
 	"type": "module",
-	"version": "7.4.4",
+	"version": "7.4.5",
 	"scripts": {
 		"dev": "vite dev",
 		"build:js-sdk": "npm --prefix ../packages/js-sdk install --include=dev && npm --prefix ../packages/js-sdk run build",

--- a/ui/src/lib/mcp/UnifiedMCPHandler.ts
+++ b/ui/src/lib/mcp/UnifiedMCPHandler.ts
@@ -361,12 +361,24 @@ export class UnifiedMCPHandler {
 					status: 404,
 					message
 				};
+				// This payload IS the answer the worker/model consumes, so only promote
+				// caller-facing recovery hints. Do NOT spread the raw REST `details`,
+				// which carries diagnostics (stack, endpoint/path/params, timestamp,
+				// trace) that must not leak into a normal tool result (PR #31 review).
 				if (errorDetails && typeof errorDetails === 'object') {
-					if (Object.keys(errorDetails).length > 0) payload.details = errorDetails;
-					if (errorDetails.languageVariants)
-						payload.languageVariants = errorDetails.languageVariants;
-					if (errorDetails.requestedLanguage)
-						payload.requestedLanguage = errorDetails.requestedLanguage;
+					const CALLER_FACING = [
+						'languageVariants',
+						'requestedLanguage',
+						'availableVariants',
+						'suggestion',
+						'availableBooks',
+						'validBookCodes',
+						'invalidCode',
+						'toc'
+					];
+					for (const key of CALLER_FACING) {
+						if (errorDetails[key] !== undefined) payload[key] = errorDetails[key];
+					}
 				}
 				console.log(
 					`[UNIFIED HANDLER] Resource not available (404) for ${toolName} — returning non-error result:`,

--- a/ui/src/lib/mcp/UnifiedMCPHandler.ts
+++ b/ui/src/lib/mcp/UnifiedMCPHandler.ts
@@ -345,6 +345,39 @@ export class UnifiedMCPHandler {
 				console.warn('[UNIFIED HANDLER] Failed to parse error response body');
 			}
 
+			// A 404 means the requested resource isn't published/available — an
+			// EXPECTED outcome, NOT a server failure. Return it as a NORMAL
+			// (isError:false) result so downstream consumers (bt-servant-worker)
+			// don't treat it as an outage and trip their health circuit, which is
+			// what surfaced to users as "the translation-helps server is down"
+			// (issue #30 / #12).
+			if (response.status === 404) {
+				const message =
+					(errorBody && (errorBody.error || errorBody.message)) ||
+					'The requested resource is not available.';
+				const payload: Record<string, unknown> = {
+					available: false,
+					code: (errorBody && errorBody.code) || 'RESOURCE_NOT_AVAILABLE',
+					status: 404,
+					message
+				};
+				if (errorDetails && typeof errorDetails === 'object') {
+					if (Object.keys(errorDetails).length > 0) payload.details = errorDetails;
+					if (errorDetails.languageVariants)
+						payload.languageVariants = errorDetails.languageVariants;
+					if (errorDetails.requestedLanguage)
+						payload.requestedLanguage = errorDetails.requestedLanguage;
+				}
+				console.log(
+					`[UNIFIED HANDLER] Resource not available (404) for ${toolName} — returning non-error result:`,
+					message
+				);
+				return {
+					content: [{ type: 'text', text: JSON.stringify(payload) }],
+					isError: false
+				};
+			}
+
 			// Create enhanced error with details attached (message includes API validation text for clients/tests)
 			const error: any = new Error(formatEndpointFailureMessage(response.status, errorBody));
 			error.status = response.status;

--- a/ui/src/lib/mcp/UnifiedMCPHandler.ts
+++ b/ui/src/lib/mcp/UnifiedMCPHandler.ts
@@ -352,9 +352,15 @@ export class UnifiedMCPHandler {
 			// what surfaced to users as "the translation-helps server is down"
 			// (issue #30 / #12).
 			if (response.status === 404) {
-				const message =
+				// Some endpoints append a verbose `(Trace: {...})` X-ray blob to the
+				// error message; strip it so it doesn't ride along in this model-facing
+				// result (PR #31 review).
+				const rawMessage =
 					(errorBody && (errorBody.error || errorBody.message)) ||
 					'The requested resource is not available.';
+				const message = String(rawMessage)
+					.replace(/\s*\(Trace:\s*\{[\s\S]*\}\)\s*$/, '')
+					.trim();
 				const payload: Record<string, unknown> = {
 					available: false,
 					code: (errorBody && errorBody.code) || 'RESOURCE_NOT_AVAILABLE',

--- a/ui/src/lib/simpleEndpoint.ts
+++ b/ui/src/lib/simpleEndpoint.ts
@@ -736,9 +736,15 @@ export function createSimpleEndpoint(config: SimpleEndpointConfig): RequestHandl
 			// Custom error handling
 			if (config.onError && error instanceof Error) {
 				const { status, message } = config.onError(error);
+				// A 404 means "resource not available" — tag it with a stable, machine-
+				// readable code so consumers can distinguish it from a server outage
+				// (issue #30). Honor an explicit code on the error if present.
+				const code =
+					(error as any)?.code || (status === 404 ? 'RESOURCE_NOT_AVAILABLE' : undefined);
 				return json(
 					{
 						error: message,
+						...(code ? { code } : {}),
 						details: errorDetails,
 						status
 					},
@@ -818,9 +824,12 @@ export function createSimpleEndpoint(config: SimpleEndpointConfig): RequestHandl
 			}
 
 			// Default error
+			const code =
+				(error as any)?.code || (errorStatus === 404 ? 'RESOURCE_NOT_AVAILABLE' : undefined);
 			return json(
 				{
 					error: errorMessage,
+					...(code ? { code } : {}),
 					details: errorDetails,
 					status: errorStatus
 				},

--- a/ui/src/lib/version.ts
+++ b/ui/src/lib/version.ts
@@ -5,7 +5,7 @@
  */
 
 // This version is populated by the build script from package.json
-export const VERSION = '7.4.4';
+export const VERSION = '7.4.5';
 
 // Helper function to get version with 'v' prefix for display
 export const getDisplayVersion = () => `v${VERSION}`;

--- a/ui/src/routes/api/health/+server.ts
+++ b/ui/src/routes/api/health/+server.ts
@@ -16,7 +16,7 @@ import type { RequestHandler } from '@sveltejs/kit';
 import { json } from '@sveltejs/kit';
 
 // This will be replaced at build time by sync-version.js
-const BUILD_VERSION = '7.4.4';
+const BUILD_VERSION = '7.4.5';
 const BUILD_TIMESTAMP = new Date().toISOString();
 
 export const GET: RequestHandler = async ({ url, platform }) => {


### PR DESCRIPTION
## Summary
- An unpublished resource (repro: **Psalms** scripture; **#12** = translation questions) surfaced as a generic MCP tool error (`isError:true`). bt-servant-worker converts *any* `isError:true` into a health failure, so after 3 consecutive hits its circuit breaker reported **"the translation-helps server is down"** instead of "that resource isn't available."
- Makes "resource not available" an **expected outcome** end-to-end: a new `RESOURCE_NOT_AVAILABLE` (404) typed error is thrown at the unpublished/empty-result sites; REST endpoints return **404 + `code`**; and `UnifiedMCPHandler` converts a 404 into a **normal result** (`isError:false`) carrying `{available:false, code, status, message}`.
- Because the MCP result is no longer `isError`, the worker stops recording a health failure (no false "server down"), and the model receives a clean structured "not available" answer to relay. **No worker-side change required** — the fix lands on the path `/mcp` (streamable, used by the worker) → `/api/mcp` → `UnifiedMCPHandler`.

### Key changes
- `errorEnvelope.ts`: `resourceNotAvailable()` / `RESOURCE_NOT_AVAILABLE` (404) typed-error factory (retry hints preserved).
- `scripture-service.ts`, `translation-questions-service.ts`, `translation-notes-service.ts`: throw it at unpublished/empty sites (covers #30 + #12).
- `BaseService.handleError`: maps the code to 404 (never downgrades to 500).
- `simpleEndpoint.ts`: REST error bodies include `code: RESOURCE_NOT_AVAILABLE` on 404s.
- `UnifiedMCPHandler.ts`: 404 → `isError:false` not-available result.
- MCP tool handlers + `handleMCPError`: carry `code`/`status` (belt-and-suspenders for the SDK path).

## Test plan
- **New** `tests/coded-errors.test.ts` (deterministic, no server): factory, `extractErrorStatus`/`extractErrorCode`, `buildResourceUnavailableResult`, and `BaseService.handleError` 404-mapping — **11/11 pass locally**.
- `tests/error-handling.test.ts` updated to the new contract (MCP `isError:false`+`available:false`; REST `404`+`code`; no 5xx for bad references).
- `tsc` and `eslint`: zero new errors vs. baseline; svelte-check clean on touched UI files.
- CI: see checks on this PR.
- **Pending (deploy-time, per plan):** curl the MCP server (`/api/fetch-scripture?...` → 404 + code), curl bt-servant-worker `POST /api/v1/chat` (Psalms → "not available", repeated 3×+), and cf-logs before/after.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Also fixes the chronic CI route smoke test that 404s on bare /api.
Closes #26
